### PR TITLE
Hide YouTube Music (YouTube-only mode)

### DIFF
--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -763,10 +763,12 @@ struct SettingsView: View {
                     Label(String(localized: "General"), systemImage: "gearshape")
                 }
 
-            MusicSettingsView()
-                .tabItem {
-                    Label(String(localized: "Music"), systemImage: "music.note")
-                }
+            if self.settings.youTubeMusicEnabled {
+                MusicSettingsView()
+                    .tabItem {
+                        Label(String(localized: "Music"), systemImage: "music.note")
+                    }
+            }
 
             YouTubeSettingsView()
                 .tabItem {

--- a/Sources/Kaset/Services/SettingsManager.swift
+++ b/Sources/Kaset/Services/SettingsManager.swift
@@ -11,6 +11,7 @@ final class SettingsManager {
 
     enum Keys {
         static let appSource = "settings.appSource"
+        static let youTubeMusicEnabled = "settings.youTubeMusicEnabled"
         static let showNowPlayingNotifications = "settings.showNowPlayingNotifications"
         static let defaultLaunchPage = "settings.defaultLaunchPage"
         static let hapticFeedbackEnabled = "settings.hapticFeedbackEnabled"
@@ -224,6 +225,18 @@ final class SettingsManager {
     var appSource: AppSource {
         didSet {
             UserDefaults.standard.set(self.appSource.rawValue, forKey: Keys.appSource)
+        }
+    }
+
+    /// Whether the YouTube Music experience is available. When off, the Music
+    /// surface, its source toggle, and the Music settings tab are hidden and the
+    /// app stays on regular YouTube (feature request #8).
+    var youTubeMusicEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(self.youTubeMusicEnabled, forKey: Keys.youTubeMusicEnabled)
+            if !self.youTubeMusicEnabled, self.appSource == .music {
+                self.appSource = .video
+            }
         }
     }
 
@@ -623,8 +636,14 @@ final class SettingsManager {
             self.contentLanguage = .system
         }
 
-        if let rawValue = UserDefaults.standard.string(forKey: Keys.appSource),
-           let source = AppSource(rawValue: rawValue)
+        let musicEnabled = UserDefaults.standard.object(forKey: Keys.youTubeMusicEnabled) as? Bool ?? true
+        self.youTubeMusicEnabled = musicEnabled
+
+        if !musicEnabled {
+            // Music disabled → always land on YouTube regardless of the saved source.
+            self.appSource = .video
+        } else if let rawValue = UserDefaults.standard.string(forKey: Keys.appSource),
+                  let source = AppSource(rawValue: rawValue)
         {
             self.appSource = source
         } else {

--- a/Sources/Kaset/Views/GeneralSettingsView.swift
+++ b/Sources/Kaset/Views/GeneralSettingsView.swift
@@ -43,6 +43,10 @@ struct GeneralSettingsView: View {
             // MARK: - Behavior Section
 
             Section {
+                // Show YouTube Music (feature request #8: YouTube-only mode)
+                Toggle(String(localized: "Show YouTube Music"), isOn: self.$settings.youTubeMusicEnabled)
+                    .help(String(localized: "Show the YouTube Music experience and its source toggle. Turn this off to use KasetPlus for YouTube only."))
+
                 // Haptic Feedback
                 Toggle("Haptic Feedback", isOn: self.$settings.hapticFeedbackEnabled)
                     .help(String(localized: "Provide tactile feedback for actions on Force Touch trackpads"))

--- a/Sources/Kaset/Views/SharedViews/SidebarFooterView.swift
+++ b/Sources/Kaset/Views/SharedViews/SidebarFooterView.swift
@@ -5,6 +5,8 @@ import SwiftUI
 /// Used by `Sidebar` (YouTube Music) and `YouTubeSidebar` so the toggle and
 /// account control render identically in both experiences.
 struct SidebarFooterView: View {
+    @State private var settings = SettingsManager.shared
+
     var body: some View {
         VStack(spacing: 0) {
             Divider()
@@ -12,9 +14,12 @@ struct SidebarFooterView: View {
 
             SidebarProfileView()
 
-            SourceToggleView()
-                .padding(.horizontal, 12)
-                .padding(.bottom, 8)
+            // The source toggle only makes sense when both surfaces exist.
+            if self.settings.youTubeMusicEnabled {
+                SourceToggleView()
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 8)
+            }
         }
     }
 }


### PR DESCRIPTION
## **User description**
Closes #8.

Adds a **Show YouTube Music** toggle in **Settings → General** (on by default). When turned off, KasetPlus becomes YouTube-only:

- The sidebar **source toggle** (Music/YouTube) is hidden.
- The **Music** settings tab is hidden.
- The app stays on regular YouTube — the saved source is forced to `.video` on launch and when the toggle is switched off.

Turning it back on restores everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Hide YouTube Music and keep the app on YouTube-only mode**

### What Changed
- Added a setting to turn YouTube Music on or off from General settings
- When YouTube Music is turned off, the Music tab and the sidebar source switch disappear
- If the app was set to Music, it now switches back to regular YouTube when YouTube Music is disabled
- Turning YouTube Music back on restores the Music tab and source switch

### Impact
`✅ Cleaner YouTube-only experience`
`✅ Fewer accidental switches to Music`
`✅ Simpler settings when Music is disabled`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
