### PR TITLE
Add 30-second YouTube arrow-key seeking

### DIFF
--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -373,6 +373,19 @@ struct KasetApp: App {
                 .keyboardShortcut(self.playbackShortcut(.space, modifiers: []))
                 .disabled(self.shouldDisablePlaybackCommand)
 
+                // YouTube video seek - ← / →
+                Button(String(localized: "Back 30 Seconds")) {
+                    self.youtubePlayerService.seekBackward()
+                }
+                .keyboardShortcut(self.playbackShortcut(.leftArrow, modifiers: []))
+                .disabled(self.shouldDisableVideoSeekCommands)
+
+                Button(String(localized: "Forward 30 Seconds")) {
+                    self.youtubePlayerService.seekForward()
+                }
+                .keyboardShortcut(self.playbackShortcut(.rightArrow, modifiers: []))
+                .disabled(self.shouldDisableVideoSeekCommands)
+
                 Divider()
 
                 // Next Track - ⌘→
@@ -689,6 +702,12 @@ struct KasetApp: App {
 
     private var shouldDisableTrackNavigationCommands: Bool {
         !self.playbackArbiter.routesMediaKeysToVideo && self.playerService.currentEpisode != nil
+    }
+
+    private var shouldDisableVideoSeekCommands: Bool {
+        self.textInputFocusState.isFocused
+            || !self.playbackArbiter.routesMediaKeysToVideo
+            || self.youtubePlayerService.currentVideo == nil
     }
 
     /// Label for repeat mode menu item.

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -7,8 +7,10 @@ Kaset provides keyboard control for playback and navigation while preserving sta
 | Shortcut | Action                              |
 | -------- | ----------------------------------- |
 | `Space`  | Play / Pause                        |
-| `⌘→`     | Next track                          |
-| `⌘←`     | Previous track                      |
+| `→`      | Seek forward 30 seconds (YouTube video only) |
+| `←`      | Seek backward 30 seconds (YouTube video only) |
+| `⌘→`     | Next track or video                 |
+| `⌘←`     | Previous track or video             |
 | `⌘↑`     | Volume up                           |
 | `⌘↓`     | Volume down                         |
 | `⌘S`     | Toggle shuffle (off/on; the player-bar control also cycles to Smart Shuffle) |


### PR DESCRIPTION
## Description

Adds plain Left and Right Arrow shortcuts for seeking the active YouTube video
backward or forward by 30 seconds. Existing Command+Arrow next/previous
shortcuts are unchanged.

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] UI/UX improvement

## Changes Made

- Route plain Left and Right Arrow to the existing YouTube 30-second seek actions.
- Disable the shortcuts while text input is focused, video routing is inactive,
  or no YouTube video is loaded.
- Document the new shortcuts and clarify the existing Command+Arrow behavior.

## Testing

- [x] `swift test --skip KasetUITests --filter 'YouTubePlayerServiceTests.*relativeSeek'`
  passed all 3 selected tests.
- [x] `swiftformat --lint Sources/Kaset/KasetApp.swift`
- [x] `swiftlint lint --strict Sources/Kaset/KasetApp.swift`
- [ ] UI test suite not run.

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Documentation is updated.
- [x] The changed source file introduces no lint violations or formatting changes.
- [x] The shortcuts preserve text-entry focus and existing music controls.

## Additional Notes

This is intentionally scoped to YouTube video playback. YouTube Music continues
to use its existing controls.
