### PR TITLE
feat(youtube): search result filters (upload date, duration, type, sort)

### DIFF
--- a/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
+++ b/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
@@ -100,6 +100,10 @@ struct YouTubeSearchResponse {
     var channels: [YouTubeChannel]
     var playlists: [YouTubePlaylist]
     var continuation: String?
+    /// Filter groups YouTube offers for this search (Type, Upload date, Duration,
+    /// Features, Sort by). Each option carries the opaque `params` to re-run the
+    /// search with it applied — cumulative, straight from the response.
+    var filterGroups: [YouTubeSearchFilterGroup] = []
 
     static let empty = YouTubeSearchResponse(
         videos: [],
@@ -113,44 +117,34 @@ struct YouTubeSearchResponse {
     }
 }
 
-// MARK: - YouTubeSearchFilter
+// MARK: - YouTubeSearchFilterGroup
 
-/// Search result filters mapped to InnerTube `params` values.
-enum YouTubeSearchFilter: String, CaseIterable, Identifiable {
-    case all
-    case videos
-    case channels
-    case playlists
+/// One group of search filters YouTube offers (e.g. "Upload date", "Duration",
+/// "Type", "Sort by"). The options — and the opaque `params` used to apply them
+/// — come straight from the search response's `searchFilterGroupRenderer`, so
+/// applying a filter just replays YouTube's own `searchEndpoint.params`.
+struct YouTubeSearchFilterGroup: Identifiable, Hashable {
+    let title: String
+    let options: [Option]
 
-    var id: String {
-        rawValue
-    }
+    var id: String { self.title }
 
-    var displayName: String {
-        switch self {
-        case .all:
-            String(localized: "All")
-        case .videos:
-            String(localized: "Videos")
-        case .channels:
-            String(localized: "Channels")
-        case .playlists:
-            String(localized: "Playlists")
-        }
-    }
+    /// The currently-applied option in this group, if any.
+    var selectedOption: Option? { self.options.first(where: \.isSelected) }
 
-    /// InnerTube search `params` value for this filter (confirmed via api-explorer).
-    var params: String? {
-        switch self {
-        case .all:
-            nil
-        case .videos:
-            "EgIQAQ=="
-        case .channels:
-            "EgIQAg=="
-        case .playlists:
-            "EgIQAw=="
-        }
+    struct Option: Identifiable, Hashable {
+        /// Localized label straight from YouTube (e.g. "This week").
+        let label: String
+        /// Opaque `params` to re-run the search with this filter applied. `nil`
+        /// for the default no-op option (e.g. "Relevance") which YouTube exposes
+        /// without an endpoint.
+        let params: String?
+        /// Whether this option is the active selection (from the response status).
+        let isSelected: Bool
+        /// Whether the option is unavailable for the current query/filters.
+        let isDisabled: Bool
+
+        var id: String { self.label }
     }
 }
 

--- a/Sources/Kaset/Services/API/MockUITestYouTubeClient.swift
+++ b/Sources/Kaset/Services/API/MockUITestYouTubeClient.swift
@@ -48,37 +48,20 @@ final class MockUITestYouTubeClient: YouTubeClientProtocol {
         YouTubeFeed(videos: Self.sampleVideos, continuation: nil)
     }
 
-    func search(query _: String, filter: YouTubeSearchFilter) async throws -> YouTubeSearchResponse {
-        switch filter {
-        case .all:
-            YouTubeSearchResponse(
-                videos: Self.sampleVideos,
-                channels: [Self.sampleChannel],
-                playlists: [Self.samplePlaylist],
-                continuation: nil
-            )
-        case .videos:
-            YouTubeSearchResponse(
-                videos: Self.sampleVideos,
-                channels: [],
-                playlists: [],
-                continuation: nil
-            )
-        case .channels:
-            YouTubeSearchResponse(
-                videos: [],
-                channels: [Self.sampleChannel],
-                playlists: [],
-                continuation: nil
-            )
-        case .playlists:
-            YouTubeSearchResponse(
-                videos: [],
-                channels: [],
-                playlists: [Self.samplePlaylist],
-                continuation: nil
-            )
-        }
+    func search(query _: String, params _: String?) async throws -> YouTubeSearchResponse {
+        var response = YouTubeSearchResponse(
+            videos: Self.sampleVideos,
+            channels: [Self.sampleChannel],
+            playlists: [Self.samplePlaylist],
+            continuation: nil
+        )
+        response.filterGroups = [
+            YouTubeSearchFilterGroup(title: "Upload date", options: [
+                .init(label: "Today", params: "mock-today", isSelected: false, isDisabled: false),
+                .init(label: "This week", params: "mock-week", isSelected: false, isDisabled: false),
+            ]),
+        ]
+        return response
     }
 
     func getSearchContinuation() async throws -> YouTubeSearchResponse? {

--- a/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeSearchParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeSearchParser.swift
@@ -29,7 +29,64 @@ enum YouTubeSearchParser {
             }
         }
 
+        response.filterGroups = Self.filterGroups(of: data)
         return response
+    }
+
+    // MARK: - Filters
+
+    /// Parses the search filter groups (Type, Upload date, Duration, Features,
+    /// Sort by) from the "Filters" dialog in the search header. Each option
+    /// carries the opaque `searchEndpoint.params` to re-run the search with it
+    /// applied. Found via a scoped recursive walk since YouTube has moved this
+    /// between `subMenu` and the header filter button across layouts.
+    static func filterGroups(of data: [String: Any]) -> [YouTubeSearchFilterGroup] {
+        var renderers: [[String: Any]] = []
+        Self.collectFilterGroupRenderers(in: data["header"] ?? data, into: &renderers)
+        return renderers.compactMap(Self.filterGroup(from:))
+    }
+
+    private static func collectFilterGroupRenderers(in value: Any, into out: inout [[String: Any]]) {
+        if let dict = value as? [String: Any] {
+            if let renderer = dict["searchFilterGroupRenderer"] as? [String: Any] {
+                out.append(renderer)
+            }
+            for nested in dict.values {
+                Self.collectFilterGroupRenderers(in: nested, into: &out)
+            }
+        } else if let array = value as? [Any] {
+            for element in array {
+                Self.collectFilterGroupRenderers(in: element, into: &out)
+            }
+        }
+    }
+
+    private static func filterGroup(from renderer: [String: Any]) -> YouTubeSearchFilterGroup? {
+        guard let title = YouTubeItemParser.text(from: renderer["title"]),
+              let filters = renderer["filters"] as? [[String: Any]]
+        else {
+            return nil
+        }
+
+        let options: [YouTubeSearchFilterGroup.Option] = filters.compactMap { filter in
+            guard let inner = filter["searchFilterRenderer"] as? [String: Any],
+                  let label = YouTubeItemParser.text(from: inner["label"])
+            else {
+                return nil
+            }
+            let params = ((inner["navigationEndpoint"] as? [String: Any])?["searchEndpoint"]
+                as? [String: Any])?["params"] as? String
+            let status = inner["status"] as? String
+            return YouTubeSearchFilterGroup.Option(
+                label: label,
+                params: params,
+                isSelected: status == "FILTER_STATUS_SELECTED",
+                isDisabled: status == "FILTER_STATUS_DISABLED"
+            )
+        }
+
+        guard !options.isEmpty else { return nil }
+        return YouTubeSearchFilterGroup(title: title, options: options)
     }
 
     /// Parses a search continuation response.

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -211,11 +211,11 @@ final class YouTubeClient: YouTubeClientProtocol { // swiftlint:disable:this typ
 
     // MARK: - Search
 
-    func search(query: String, filter: YouTubeSearchFilter) async throws -> YouTubeSearchResponse {
-        self.logger.info("Searching YouTube (filter: \(filter.rawValue))")
+    func search(query: String, params: String?) async throws -> YouTubeSearchResponse {
+        self.logger.info("Searching YouTube")
 
         var body: [String: Any] = ["query": query]
-        if let params = filter.params {
+        if let params {
             body["params"] = params
         }
 

--- a/Sources/Kaset/Services/YouTubeProtocols.swift
+++ b/Sources/Kaset/Services/YouTubeProtocols.swift
@@ -43,8 +43,9 @@ protocol YouTubeClientProtocol: Sendable {
 
     // MARK: Search
 
-    /// Searches YouTube with an optional result-kind filter.
-    func search(query: String, filter: YouTubeSearchFilter) async throws -> YouTubeSearchResponse
+    /// Searches YouTube, optionally applying an opaque filter `params` token
+    /// (from a `YouTubeSearchFilterGroup.Option`).
+    func search(query: String, params: String?) async throws -> YouTubeSearchResponse
 
     /// Fetches the next page of the current search, or `nil` when exhausted.
     func getSearchContinuation() async throws -> YouTubeSearchResponse?

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeSearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeSearchViewModel.swift
@@ -20,13 +20,16 @@ final class YouTubeSearchViewModel {
     /// Search results.
     private(set) var results: YouTubeSearchResponse = .empty
 
-    /// Filter for result kinds.
-    var selectedFilter: YouTubeSearchFilter = .all {
-        didSet {
-            guard oldValue != self.selectedFilter else { return }
-            self.handleFilterChange()
-        }
-    }
+    /// Filter groups YouTube offers for the current query (Type, Upload date,
+    /// Duration, Features, Sort by). Persisted across filter re-searches so the
+    /// filter bar stays stable while results reload.
+    private(set) var filterGroups: [YouTubeSearchFilterGroup] = []
+
+    /// The applied filter `params` token, or nil when no filter is active.
+    private(set) var appliedFilterParams: String?
+
+    /// Whether any search filter is currently applied.
+    var hasActiveFilters: Bool { self.appliedFilterParams != nil }
 
     @ObservationIgnored private var searchTask: Task<Void, Never>?
     @ObservationIgnored private var paginationTask: Task<Void, Never>?
@@ -85,7 +88,21 @@ final class YouTubeSearchViewModel {
     private var currentSearchContext: SearchContext? {
         let query = Self.normalizedQuery(self.query)
         guard !query.isEmpty else { return nil }
-        return SearchContext(query: query, filter: self.selectedFilter)
+        return SearchContext(query: query, params: self.appliedFilterParams)
+    }
+
+    /// Applies a filter option (from `filterGroups`) and re-runs the search.
+    func applyFilter(_ option: YouTubeSearchFilterGroup.Option) {
+        guard !option.isDisabled, self.appliedFilterParams != option.params else { return }
+        self.appliedFilterParams = option.params
+        self.handleFilterChange()
+    }
+
+    /// Clears all applied filters and re-runs the unfiltered search.
+    func clearFilters() {
+        guard self.appliedFilterParams != nil else { return }
+        self.appliedFilterParams = nil
+        self.handleFilterChange()
     }
 
     private static func normalizedQuery(_ query: String) -> String {
@@ -98,6 +115,9 @@ final class YouTubeSearchViewModel {
         guard oldQuery != newQuery else { return }
 
         self.invalidateInFlightSearch()
+        // A new query starts fresh: drop any applied filters and their groups.
+        self.appliedFilterParams = nil
+        self.filterGroups = []
 
         if newQuery.isEmpty {
             self.resetForEmptyQuery()
@@ -154,11 +174,15 @@ final class YouTubeSearchViewModel {
         }
 
         do {
-            let results = try await client.search(query: request.context.query, filter: request.context.filter)
+            let results = try await client.search(query: request.context.query, params: request.context.params)
             guard self.isCurrentSearch(request) else { return }
             guard !Task.isCancelled else { return }
 
             self.results = results
+            // Keep the last non-empty filter set so the bar stays put on reloads.
+            if !results.filterGroups.isEmpty {
+                self.filterGroups = results.filterGroups
+            }
             self.publishedSearchContext = request.context
             self.publishedSearchGeneration = request.generation
             self.loadingState = .loaded
@@ -261,6 +285,8 @@ final class YouTubeSearchViewModel {
         self.loadingState = .idle
         self.publishedSearchContext = nil
         self.publishedSearchGeneration = nil
+        self.filterGroups = []
+        self.appliedFilterParams = nil
     }
 
     private func isCurrentSearch(_ request: SearchRequest) -> Bool {
@@ -285,7 +311,7 @@ final class YouTubeSearchViewModel {
 
 private struct SearchContext: Equatable {
     let query: String
-    let filter: YouTubeSearchFilter
+    let params: String?
 }
 
 // MARK: - SearchRequest

--- a/Sources/Kaset/Views/YouTube/YouTubeSearchView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeSearchView.swift
@@ -75,19 +75,89 @@ struct YouTubeSearchView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .background(.quaternary.opacity(0.5), in: Capsule())
+            .padding(.horizontal, 20)
 
-            Picker(String(localized: "Filter"), selection: self.$viewModel.selectedFilter) {
-                ForEach(YouTubeSearchFilter.allCases) { filter in
-                    Text(filter.displayName).tag(filter)
-                }
+            // Full-width so the filter chips can scroll edge-to-edge.
+            if !self.viewModel.filterGroups.isEmpty {
+                self.filterBar
             }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .accessibilityIdentifier(AccessibilityID.YouTubeContent.searchFilter)
         }
-        .padding(.horizontal, 20)
         .padding(.top, 16)
         .padding(.bottom, 12)
+    }
+
+    // MARK: - Filter Bar
+
+    /// A horizontal row of glass-capsule menus, one per YouTube filter group
+    /// (Type, Upload date, Duration, Features, Sort by), plus a Clear chip.
+    private var filterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(self.viewModel.filterGroups) { group in
+                    self.filterMenu(group)
+                }
+
+                if self.viewModel.hasActiveFilters {
+                    Button {
+                        self.viewModel.clearFilters()
+                    } label: {
+                        HStack(spacing: 5) {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 10, weight: .semibold))
+                            Text("Clear", comment: "Clear search filters")
+                                .font(.system(size: 12, weight: .medium))
+                        }
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 12)
+                        .frame(height: 30)
+                        .compatGlass(interactive: true, tint: nil, in: Capsule())
+                        .contentShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(String(localized: "Clear filters"))
+                }
+            }
+            .padding(.horizontal, 20)
+        }
+        .accessibilityIdentifier(AccessibilityID.YouTubeContent.searchFilter)
+    }
+
+    private func filterMenu(_ group: YouTubeSearchFilterGroup) -> some View {
+        // A filter is "active" only when its selected option carries params
+        // (YouTube marks a default no-op like "Relevance" selected with no endpoint).
+        let selected = group.selectedOption
+        let isActive = selected?.params != nil
+
+        return Menu {
+            ForEach(group.options) { option in
+                Button {
+                    self.viewModel.applyFilter(option)
+                } label: {
+                    if option.isSelected {
+                        Label(option.label, systemImage: "checkmark")
+                    } else {
+                        Text(option.label)
+                    }
+                }
+                .disabled(option.isDisabled)
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Text(isActive ? (selected?.label ?? group.title) : group.title)
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+            }
+            .foregroundStyle(isActive ? AnyShapeStyle(.white) : AnyShapeStyle(.primary))
+            .padding(.horizontal, 12)
+            .frame(height: 30)
+            .compatGlass(interactive: true, tint: isActive ? Color.accentColor : nil, in: Capsule())
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .fixedSize()
     }
 
     private var emptyState: some View {
@@ -104,7 +174,9 @@ struct YouTubeSearchView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 12) {
                 if !self.viewModel.results.channels.isEmpty {
-                    self.sectionHeader(String(localized: "Channels"))
+                    if self.showsSectionHeaders {
+                        self.sectionHeader(String(localized: "Channels"))
+                    }
                     ForEach(self.viewModel.results.channels) { channel in
                         NavigationLink(value: YouTubeRoute.channel(channelId: channel.channelId)) {
                             ChannelRowView(channel: channel)
@@ -114,7 +186,7 @@ struct YouTubeSearchView: View {
                 }
 
                 if !self.viewModel.results.videos.isEmpty {
-                    if self.viewModel.selectedFilter == .all {
+                    if self.showsSectionHeaders {
                         self.sectionHeader(String(localized: "Videos"))
                     }
                     ForEach(self.viewModel.results.videos) { video in
@@ -126,7 +198,7 @@ struct YouTubeSearchView: View {
                 }
 
                 if !self.viewModel.results.playlists.isEmpty {
-                    if self.viewModel.selectedFilter == .all {
+                    if self.showsSectionHeaders {
                         self.sectionHeader(String(localized: "Playlists"))
                     }
                     ForEach(self.viewModel.results.playlists) { playlist in
@@ -150,6 +222,16 @@ struct YouTubeSearchView: View {
             .padding(.bottom, 20)
         }
         .accessibilityIdentifier(AccessibilityID.YouTubeContent.searchResults)
+    }
+
+    /// Section headers ("Videos"/"Channels"/"Playlists") only help when more
+    /// than one kind of result is present; a filtered search shows just one.
+    private var showsSectionHeaders: Bool {
+        [
+            !self.viewModel.results.channels.isEmpty,
+            !self.viewModel.results.videos.isEmpty,
+            !self.viewModel.results.playlists.isEmpty,
+        ].filter { $0 }.count > 1
     }
 
     private func sectionHeader(_ title: String) -> some View {

--- a/Tests/KasetTests/GuestModeAPIClientTests.swift
+++ b/Tests/KasetTests/GuestModeAPIClientTests.swift
@@ -35,7 +35,7 @@ struct GuestModeAPIClientTests {
         defer { MockURLProtocol.reset(session: session) }
 
         let client = YouTubeClient(authService: authService, session: session)
-        let response = try await client.search(query: "swift", filter: .all)
+        let response = try await client.search(query: "swift", params: nil)
 
         #expect(response.videos.isEmpty)
         #expect(apiRequestCount == 1)
@@ -176,7 +176,7 @@ struct GuestModeAPIClientTests {
         defer { MockURLProtocol.reset(session: session) }
 
         let client = YouTubeClient(authService: authService, session: session)
-        let response = try await client.search(query: "swift", filter: .all)
+        let response = try await client.search(query: "swift", params: nil)
 
         #expect(response.videos.isEmpty)
         #expect(apiRequestCount == 1)

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -31,10 +31,10 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     private(set) var homeFeedCallCount = 0
     private(set) var searchCallCount = 0
     private(set) var lastSearchQuery: String?
-    private(set) var lastSearchFilter: YouTubeSearchFilter?
+    private(set) var lastSearchParams: String?
 
-    nonisolated static func searchKey(query: String, filter: YouTubeSearchFilter) -> String {
-        "\(filter.rawValue)|\(query)"
+    nonisolated static func searchKey(query: String, params: String?) -> String {
+        "\(params ?? "all")|\(query)"
     }
 
     var hasMoreHomeFeed: Bool {
@@ -146,19 +146,19 @@ final class MockYouTubeClient: YouTubeClientProtocol {
 
     /// Awaited inside `search` before it returns, so a test can hold one
     /// search request open while a newer query/filter search completes first.
-    var beforeSearchReturn: (@Sendable (String, YouTubeSearchFilter) async -> Void)?
+    var beforeSearchReturn: (@Sendable (String, String?) async -> Void)?
 
-    func search(query: String, filter: YouTubeSearchFilter) async throws -> YouTubeSearchResponse {
+    func search(query: String, params: String?) async throws -> YouTubeSearchResponse {
         if let error {
             throw error
         }
         self.searchCallCount += 1
         self.lastSearchQuery = query
-        self.lastSearchFilter = filter
+        self.lastSearchParams = params
         if let beforeSearchReturn {
-            await beforeSearchReturn(query, filter)
+            await beforeSearchReturn(query, params)
         }
-        let key = Self.searchKey(query: query, filter: filter)
+        let key = Self.searchKey(query: query, params: params)
         return self.searchResponsesByRequest[key] ?? self.searchResponse
     }
 

--- a/Tests/KasetTests/YouTubeResponseParserTests.swift
+++ b/Tests/KasetTests/YouTubeResponseParserTests.swift
@@ -69,6 +69,55 @@ struct YouTubeSearchParserTests {
         #expect(first.firstVideoId == "zW5wpJY1rgQ")
         #expect(!first.title.isEmpty)
     }
+
+    @Test("Parses search filter groups with their params and selected status")
+    func parsesFilterGroups() throws {
+        func filter(_ label: String, _ params: String?, _ status: String?) -> [String: Any] {
+            var renderer: [String: Any] = ["label": ["simpleText": label]]
+            if let params {
+                renderer["navigationEndpoint"] = ["searchEndpoint": ["params": params]]
+            }
+            if let status {
+                renderer["status"] = status
+            }
+            return ["searchFilterRenderer": renderer]
+        }
+        let response = YouTubeSearchParser.parse([
+            "header": ["searchHeaderRenderer": ["searchFilterButton": ["buttonRenderer": [
+                "command": ["openPopupAction": ["popup": ["searchFilterOptionsDialogRenderer": [
+                    "groups": [
+                        ["searchFilterGroupRenderer": [
+                            "title": ["simpleText": "Upload date"],
+                            "filters": [
+                                filter("Today", "EgIIAg==", nil),
+                                filter("This week", "EgIIAw==", "FILTER_STATUS_SELECTED"),
+                            ],
+                        ]],
+                        ["searchFilterGroupRenderer": [
+                            "title": ["simpleText": "Sort by"],
+                            "filters": [
+                                filter("Relevance", nil, "FILTER_STATUS_SELECTED"),
+                                filter("Rating", "CAE=", "FILTER_STATUS_DISABLED"),
+                            ],
+                        ]],
+                    ],
+                ]]]],
+            ]]]],
+        ])
+
+        #expect(response.filterGroups.count == 2)
+        let upload = try #require(response.filterGroups.first)
+        #expect(upload.title == "Upload date")
+        #expect(upload.options.count == 2)
+        #expect(upload.selectedOption?.label == "This week")
+        #expect(upload.options.first?.params == "EgIIAg==")
+
+        let sort = response.filterGroups[1]
+        // The default no-op option ("Relevance") is selected but carries no params.
+        #expect(sort.selectedOption?.label == "Relevance")
+        #expect(sort.selectedOption?.params == nil)
+        #expect(sort.options[1].isDisabled)
+    }
 }
 
 // MARK: - YouTubeFeedParserTests

--- a/Tests/KasetTests/YouTubeSearchViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeSearchViewModelTests.swift
@@ -15,7 +15,7 @@ struct YouTubeSearchViewModelTests {
         self.sut = YouTubeSearchViewModel(client: self.mockClient)
     }
 
-    @Test("Search sends the query and selected filter to the client")
+    @Test("Search sends the query and applied filter params to the client")
     func searchSendsQueryAndFilter() async {
         self.mockClient.searchResponse = YouTubeSearchResponse(
             videos: MockYouTubeClient.makeVideos(count: 2),
@@ -24,14 +24,19 @@ struct YouTubeSearchViewModelTests {
             continuation: nil
         )
         self.sut.query = "swift"
-        self.sut.selectedFilter = .videos
+        self.sut.applyFilter(Self.option(params: "EgIQAQ=="))
 
         await self.sut.search()
 
         #expect(self.mockClient.lastSearchQuery == "swift")
-        #expect(self.mockClient.lastSearchFilter == .videos)
+        #expect(self.mockClient.lastSearchParams == "EgIQAQ==")
         #expect(self.sut.results.videos.count == 2)
         #expect(self.sut.loadingState == .loaded)
+    }
+
+    /// Builds a filter option for tests (label/status don't affect the request).
+    private static func option(params: String?) -> YouTubeSearchFilterGroup.Option {
+        .init(label: params ?? "All", params: params, isSelected: false, isDisabled: false)
     }
 
     @Test("Empty query does not hit the client")
@@ -164,13 +169,13 @@ struct YouTubeSearchViewModelTests {
     func lateOlderQueryCannotOverwriteNewerQuery() async {
         let oldQueryGate = AsyncGate()
         self.mockClient.searchResponsesByRequest = [
-            MockYouTubeClient.searchKey(query: "swift", filter: .all): YouTubeSearchResponse(
+            MockYouTubeClient.searchKey(query: "swift", params: nil): YouTubeSearchResponse(
                 videos: [MockYouTubeClient.makeVideo(videoId: "old-query")],
                 channels: [],
                 playlists: [],
                 continuation: "old-token"
             ),
-            MockYouTubeClient.searchKey(query: "swiftui", filter: .all): YouTubeSearchResponse(
+            MockYouTubeClient.searchKey(query: "swiftui", params: nil): YouTubeSearchResponse(
                 videos: [MockYouTubeClient.makeVideo(videoId: "new-query")],
                 channels: [],
                 playlists: [],
@@ -205,13 +210,13 @@ struct YouTubeSearchViewModelTests {
     func stalePaginationCannotCorruptNewerSearchContinuation() async {
         let paginationGate = AsyncGate()
         self.mockClient.searchResponsesByRequest = [
-            MockYouTubeClient.searchKey(query: "swift", filter: .all): YouTubeSearchResponse(
+            MockYouTubeClient.searchKey(query: "swift", params: nil): YouTubeSearchResponse(
                 videos: [MockYouTubeClient.makeVideo(videoId: "old-query")],
                 channels: [],
                 playlists: [],
                 continuation: "old-token"
             ),
-            MockYouTubeClient.searchKey(query: "swiftui", filter: .all): YouTubeSearchResponse(
+            MockYouTubeClient.searchKey(query: "swiftui", params: nil): YouTubeSearchResponse(
                 videos: [MockYouTubeClient.makeVideo(videoId: "new-query")],
                 channels: [],
                 playlists: [],
@@ -250,32 +255,34 @@ struct YouTubeSearchViewModelTests {
     @Test("Late results from an older filter cannot corrupt newer filter continuation")
     func lateOlderFilterCannotOverwriteNewerFilterOrContinuation() async {
         let oldFilterGate = AsyncGate()
+        let videosParams = "EgIQAQ=="
+        let channelsParams = "EgIQAg=="
         self.mockClient.searchResponsesByRequest = [
-            MockYouTubeClient.searchKey(query: "swift", filter: .videos): YouTubeSearchResponse(
+            MockYouTubeClient.searchKey(query: "swift", params: videosParams): YouTubeSearchResponse(
                 videos: [MockYouTubeClient.makeVideo(videoId: "old-videos")],
                 channels: [],
                 playlists: [],
                 continuation: "videos-token"
             ),
-            MockYouTubeClient.searchKey(query: "swift", filter: .channels): YouTubeSearchResponse(
+            MockYouTubeClient.searchKey(query: "swift", params: channelsParams): YouTubeSearchResponse(
                 videos: [],
                 channels: [YouTubeChannel(channelId: "new-channel", name: "New Channel")],
                 playlists: [],
                 continuation: "channels-token"
             ),
         ]
-        self.mockClient.beforeSearchReturn = { _, filter in
-            if filter == .videos {
+        self.mockClient.beforeSearchReturn = { _, params in
+            if params == videosParams {
                 await oldFilterGate.wait()
             }
         }
 
-        self.sut.selectedFilter = .videos
         self.sut.query = "swift"
+        self.sut.applyFilter(Self.option(params: videosParams))
         let oldSearch = Task { await self.sut.search() }
-        await self.waitUntil(self.mockClient.lastSearchFilter == .videos)
+        await self.waitUntil(self.mockClient.lastSearchParams == videosParams)
 
-        self.sut.selectedFilter = .channels
+        self.sut.applyFilter(Self.option(params: channelsParams))
         await self.waitUntil(self.sut.results.channels.map(\.channelId) == ["new-channel"])
 
         #expect(self.sut.results.channels.map(\.channelId) == ["new-channel"])

--- a/Tests/KasetTests/YouTubeSingleFlightViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeSingleFlightViewModelTests.swift
@@ -311,7 +311,7 @@ private final class SingleFlightYouTubeClient: YouTubeClientProtocol {
         return self.homeTopicFeed
     }
 
-    func search(query _: String, filter _: YouTubeSearchFilter) async throws -> YouTubeSearchResponse {
+    func search(query _: String, params _: String?) async throws -> YouTubeSearchResponse {
         try await self.waitIfNeeded()
         return self.searchResponse
     }


### PR DESCRIPTION
## **User description**
## Description

Closes #15. YouTube search returned a flat list with no way to narrow it. This adds YouTube's own **search filters** — **Type, Upload date, Duration, Features, Sort by** — as a filter bar above the results.

The filter options (and the opaque `params` used to apply each) come **straight from the search response** (`searchFilterGroupRenderer`), so applying a filter just replays YouTube's own `searchEndpoint.params`. They're cumulative — nothing is hand-built — which also fixes combining filters (the old hardcoded 4-case type enum couldn't).

## Design
- Horizontal bar of **glass-capsule menus** (one per group) + a **Clear** chip, matching the app's existing menu/glass idiom (player captions/quality menus, notification bell). Active filters tint with the app **accent color** and show the chosen value.
- Result section headers ("Videos"/"Channels"/"Playlists") now appear only when more than one kind of result is present.

## Changes
- **Parser**: `filterGroups` parsed from the header "Filters" dialog (scoped recursive walk); each option carries params + selected/disabled status.
- **Client/protocol**: `search(query:, params:)` applies an arbitrary filter token (replaces `filter: YouTubeSearchFilter`).
- **View model**: applied params drive the existing single-flight search; groups persist across filter reloads; a new query resets filters.

## Testing
- Explored the filter structure with `api-explorer` before implementing.
- Unit tests: new filter-group parsing test; the search single-flight tests updated to the params-based filter API. `swift test --skip KasetUITests` (search/parser/guest/single-flight) green.
- Built + ran the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add YouTube search filters for date, duration, type, features, and sorting

### What Changed
- YouTube search now shows filter menus based on the options available for the current query.
- Filters can be combined, disabled options cannot be selected, and a Clear action restores unfiltered results.
- Applying a filter refreshes results while keeping the filter controls available; starting a new query resets them.
- Result headings are hidden when only one result type is shown, reducing clutter in filtered searches.
- Added coverage for filter parsing and filtered-search request behavior.

### Impact
`✅ Narrower YouTube search results`
`✅ Combined date, type, duration, and sorting filters`
`✅ Cleaner single-type result lists`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
