### PR TITLE
fix(youtube): show upload date on home cards in non-English locales

### DIFF
--- a/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeItemParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeItemParser.swift
@@ -183,9 +183,14 @@ enum YouTubeItemParser {
         // Row 0 is typically the channel name; row 1 holds "X views · Y ago".
         let channelName = metadataRowTexts.first?.first
         let statsRow = metadataRowTexts.dropFirst().first ?? []
+        // The stats row is ordered "views · published date". Match the English
+        // keywords when present, but fall back to position so non-English
+        // locales (e.g. "…visualizzazioni" · "…fa") still surface the upload
+        // date on home/feed cards. (issue #17)
         let viewCountText = statsRow.first { $0.localizedCaseInsensitiveContains("view") }
             ?? statsRow.first
         let publishedText = statsRow.first { $0.localizedCaseInsensitiveContains("ago") }
+            ?? (statsRow.count >= 2 ? statsRow[1] : nil)
 
         let badgeText = self.thumbnailBadgeText(of: lockup)
         let isShort = self.isShort(navigationContainer: self.onTapCommand(of: lockup))

--- a/Tests/KasetTests/YouTubeItemParserTests.swift
+++ b/Tests/KasetTests/YouTubeItemParserTests.swift
@@ -149,6 +149,38 @@ struct YouTubeItemParserTests {
         #expect(video.thumbnailURL?.absoluteString == "https://example.com/thumb.jpg")
     }
 
+    @Test("Extracts the upload date from a non-English lockup by position (issue #17)")
+    func parsesNonEnglishLockupStats() throws {
+        let lockup: [String: Any] = [
+            "contentId": "it123",
+            "contentType": "LOCKUP_CONTENT_TYPE_VIDEO",
+            "metadata": [
+                "lockupMetadataViewModel": [
+                    "title": ["content": "Video Italiano"],
+                    "metadata": [
+                        "contentMetadataViewModel": [
+                            "metadataRows": [
+                                ["metadataParts": [["text": ["content": "Canale"]]]],
+                                ["metadataParts": [
+                                    ["text": ["content": "1,2 Mln di visualizzazioni"]],
+                                    ["text": ["content": "9 mesi fa"]],
+                                ]],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            "rendererContext": ["commandContext": ["onTap": ["innertubeCommand": [
+                "watchEndpoint": ["videoId": "it123"],
+            ]]]],
+        ]
+
+        let video = try #require(YouTubeItemParser.video(fromLockup: lockup))
+        #expect(video.viewCountText == "1,2 Mln di visualizzazioni")
+        // No "ago" to match → falls back to the second stats part (the date).
+        #expect(video.publishedText == "9 mesi fa")
+    }
+
     @Test("Video parser rejects playlist lockups and vice versa")
     func lockupContentTypeMismatch() {
         let playlistLockup: [String: Any] = [


### PR DESCRIPTION
## Description

Closes #17. Home video cards are meant to render **views · upload date**, but the date was missing for non-English users (Italian in the report).

The modern `lockupViewModel` stats parser told view count and date apart with **English keywords** (`"view"` / `"ago"`), so a localized date like "…**fa**" never matched → `publishedText` came back `nil` → no date.

## Fix
Fall back to **position** when the English keywords don't match: YouTube's stats row is always ordered `views · published`, so the second part is the date regardless of locale. (`viewCountText` already falls back to the first part.) Locale-independent, minimal.

- Added a unit test with an Italian lockup asserting the date is extracted.

## Note on "Continue watching"
Partially-watched / "Continue watching" cards still show no views/date — that's **YouTube's own reduced metadata** for resumed videos (they use a progress bar instead of stats). Confirmed by the fact that the *same* video carries the date in the main grid but not in the "Continue watching" shelf, both parsed through this same code path. Nothing to render when the API doesn't send it (matches youtube.com).

## Testing
- `swift test --skip KasetUITests --filter YouTubeItemParser` green (incl. the new non-English case).
- Built + ran the app: home cards now show the upload date for normal videos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)