### PR TITLE
Channel memberships: Abbonati button + members-only gate

### DIFF
--- a/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
+++ b/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
@@ -228,6 +228,9 @@ struct WatchNextData {
     var mixDescription: String?
     /// Current position in a finite playlist queue, "N/total" (nil for endless mixes).
     var mixPosition: String?
+    /// Whether the channel offers a paid membership (the watch page's owner
+    /// exposes a `membershipButton`), so we can show a "Join" (Abbonati) button.
+    var channelOffersMembership: Bool
 
     init(
         videoTitle: String?,
@@ -247,7 +250,8 @@ struct WatchNextData {
         mixPlaylistId: String? = nil,
         mixTitle: String? = nil,
         mixDescription: String? = nil,
-        mixPosition: String? = nil
+        mixPosition: String? = nil,
+        channelOffersMembership: Bool = false
     ) {
         self.videoTitle = videoTitle
         self.viewCountText = viewCountText
@@ -267,6 +271,7 @@ struct WatchNextData {
         self.mixTitle = mixTitle
         self.mixDescription = mixDescription
         self.mixPosition = mixPosition
+        self.channelOffersMembership = channelOffersMembership
     }
 
     static let empty = WatchNextData(
@@ -276,6 +281,24 @@ struct WatchNextData {
         channel: nil,
         related: []
     )
+}
+
+// MARK: - YouTubePlayability
+
+/// The `player` endpoint's `playabilityStatus`, used to show a real gate — with
+/// YouTube's own dynamic wording — for a members-only video the signed-in user
+/// can't play, instead of an endless loading spinner. YouTube gates the stream
+/// server-side (no `streamingData` is served to non-members), so this only
+/// surfaces YouTube's notice; it never bypasses the restriction.
+struct YouTubePlayability {
+    /// Whether YouTube will serve a stream (`status == "OK"`).
+    let isPlayable: Bool
+    /// YouTube's headline for why not, already localized (e.g. the members-only notice).
+    let reason: String?
+    /// YouTube's secondary explanation, already localized (e.g. the "join to get access" line).
+    let subreason: String?
+
+    static let playable = YouTubePlayability(isPlayable: true, reason: nil, subreason: nil)
 }
 
 // MARK: - YouTubeLiveChatMessage

--- a/Sources/Kaset/Resources/Localizable.xcstrings
+++ b/Sources/Kaset/Resources/Localizable.xcstrings
@@ -44812,6 +44812,17 @@
         }
       }
     },
+    "Join" : {
+      "comment" : "Button to join a channel's paid membership (it: 'Abbonati'). Opens the YouTube membership page; no in-app payment.",
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbonati"
+          }
+        }
+      }
+    },
     "Jump to chapter: %@" : {
       "comment" : "YouTube video watch page (below the player: title, channel, subscribe/bell, description, chapters, comments, related).",
       "localizations" : {

--- a/Sources/Kaset/Resources/it.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/it.lproj/Localizable.strings
@@ -241,6 +241,7 @@
 "Invalid video URL" = "URL video non valido";
 "Item %lld" = "Item %lld";
 "Jazz" = "Jazz";
+"Join" = "Abbonati";
 "Jump to chapter: %@" = "Vai al capitolo: %@";
 "Jump to chapter: %arg" = "Jump to chapter: %arg";
 "Jump to live" = "Jump to live";

--- a/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
@@ -93,8 +93,31 @@ enum WatchNextParser {
             mixPlaylistId: mix?.playlistId,
             mixTitle: mix?.title,
             mixDescription: mix?.description,
-            mixPosition: mix?.position
+            mixPosition: mix?.position,
+            // A channel that offers a paid membership exposes a `membershipButton`
+            // on its video-owner renderer (label "Join" / "Abbonati").
+            channelOffersMembership: ownerRenderer?["membershipButton"] != nil
         )
+    }
+
+    // MARK: - Playability (members-only gate)
+
+    /// Parses the `player` endpoint's `playabilityStatus` into a gate result.
+    /// For a members-only video a non-member can't watch, YouTube returns
+    /// `status != "OK"`, no `streamingData`, and an `errorScreen` carrying the
+    /// dynamic reason/subreason text we surface verbatim.
+    static func playability(_ data: [String: Any]) -> YouTubePlayability {
+        let status = data["playabilityStatus"] as? [String: Any]
+        let state = status?["status"] as? String
+        if state == "OK" || data["streamingData"] != nil {
+            return .playable
+        }
+        let renderer = ((status?["errorScreen"] as? [String: Any])?["playerErrorMessageRenderer"])
+            as? [String: Any]
+        let reason = YouTubeItemParser.text(from: renderer?["reason"])
+            ?? (status?["reason"] as? String)
+        let subreason = YouTubeItemParser.text(from: renderer?["subreason"])
+        return YouTubePlayability(isPlayable: false, reason: reason, subreason: subreason)
     }
 
     // MARK: - Mix (radio) queue

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -260,6 +260,20 @@ final class YouTubeClient: YouTubeClientProtocol { // swiftlint:disable:this typ
         return WatchNextParser.parse(data)
     }
 
+    /// Fetches the `player` playability status for a members-only gate. Signed-in
+    /// (auth `.required`) because membership access is per-account, and uncached
+    /// so a freshly-joined member sees the video unlock on the next open.
+    func getPlayability(videoId: String) async throws -> YouTubePlayability {
+        self.logger.info("Fetching playability status")
+
+        let data = try await self.request(
+            "player",
+            body: ["videoId": videoId],
+            authPolicy: .required
+        )
+        return WatchNextParser.playability(data)
+    }
+
     func getComments(continuation: String) async throws -> YouTubeCommentsPage {
         self.logger.info("Fetching YouTube comments page")
 

--- a/Sources/Kaset/Services/YouTubeProtocols.swift
+++ b/Sources/Kaset/Services/YouTubeProtocols.swift
@@ -58,6 +58,10 @@ protocol YouTubeClientProtocol: Sendable {
     /// Fetches watch-page companion data (metadata + related videos).
     func getWatchNext(videoId: String, playlistId: String?) async throws -> WatchNextData
 
+    /// Fetches the `player` playability status, used to gate members-only videos
+    /// the signed-in user can't watch (shows YouTube's own notice, not a spinner).
+    func getPlayability(videoId: String) async throws -> YouTubePlayability
+
     /// Fetches a page of comments by continuation token.
     func getComments(continuation: String) async throws -> YouTubeCommentsPage
 
@@ -161,5 +165,11 @@ extension YouTubeClientProtocol {
     /// Default so the mock/UI-test client compiles without a notifications backend.
     func getNotifications() async throws -> [YouTubeNotification] {
         []
+    }
+
+    /// Default so mocks/UI-test clients compile; the real client overrides this.
+    /// Assuming "playable" means members-only gating is simply inactive there.
+    func getPlayability(videoId _: String) async throws -> YouTubePlayability {
+        .playable
     }
 }

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeWatchViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeWatchViewModel.swift
@@ -31,6 +31,11 @@ final class YouTubeWatchViewModel {
 
     /// Whether the user is subscribed to the channel (seeded from watch-next).
     private(set) var isSubscribed = false
+
+    /// Members-only gate: YouTube's real "unplayable" notice for a members-only
+    /// video the signed-in user can't watch. Nil when the video is playable or
+    /// isn't members-only, so the watch surface shows the video (or its spinner).
+    private(set) var membersGate: YouTubePlayability?
     /// The channel's notification "bell" preference, when subscribed.
     private(set) var notificationPreference: ChannelNotificationPreference?
 
@@ -113,6 +118,7 @@ final class YouTubeWatchViewModel {
         self.loadGeneration += 1
         let generation = self.loadGeneration
         self.loadingState = .loading
+        self.membersGate = nil
         do {
             let data = try await self.client.getWatchNext(videoId: self.video.videoId, playlistId: self.video.mixPlaylistId)
             guard generation == self.loadGeneration else { return }
@@ -135,6 +141,12 @@ final class YouTubeWatchViewModel {
             if self.isLive, let liveChat = data.liveChatContinuation {
                 self.startLiveChat(continuation: liveChat, generation: generation)
             }
+            // Members-only videos never serve a stream to non-members, so the
+            // player just spins forever. Ask YouTube's `player` endpoint for the
+            // real reason and surface it as a gate instead.
+            if self.video.isMembersOnly {
+                await self.loadMembersGate(generation: generation)
+            }
             await self.loadMoreComments()
         } catch {
             guard generation == self.loadGeneration else { return }
@@ -146,6 +158,20 @@ final class YouTubeWatchViewModel {
             }
             self.logger.error("Failed to load watch-next data: \(error.localizedDescription)")
             self.loadingState = .error(LoadingError(from: error))
+        }
+    }
+
+    /// Fetches YouTube's playability status for a members-only video and, if the
+    /// signed-in user can't play it, stores the gate so the surface shows the
+    /// real notice + a "Join" (Abbonati) action instead of an endless spinner.
+    /// Non-fatal: any failure just falls back to the existing loading state.
+    private func loadMembersGate(generation: Int) async {
+        do {
+            let playability = try await self.client.getPlayability(videoId: self.video.videoId)
+            guard generation == self.loadGeneration else { return }
+            self.membersGate = playability.isPlayable ? nil : playability
+        } catch {
+            self.logger.debug("Members-only playability check failed: \(error.localizedDescription)")
         }
     }
 

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
@@ -15,6 +15,7 @@ struct YouTubeWatchView: View {
 
     @Environment(AuthService.self) private var authService
     @Environment(YouTubePlayerService.self) private var youtubePlayer
+    @Environment(\.openURL) private var openURL
     @State private var viewModel: YouTubeWatchViewModel
 
     init(video: YouTubeVideo, client: any YouTubeClientProtocol) {
@@ -241,8 +242,13 @@ struct YouTubeWatchView: View {
                 }
                 // Loading state: the WebView surface is black until the stream
                 // is ready, so show a spinner over it instead of a blank frame.
+                // For a members-only video the user can't play, no stream ever
+                // arrives — show YouTube's real gate notice instead of spinning.
                 .overlay {
-                    if self.youtubePlayer.isPlaybackLoading {
+                    if let gate = self.viewModel.membersGate {
+                        self.membersGateCard(gate)
+                            .transition(.opacity)
+                    } else if self.youtubePlayer.isPlaybackLoading {
                         ZStack {
                             Rectangle().fill(.black)
                             ProgressView()
@@ -253,6 +259,7 @@ struct YouTubeWatchView: View {
                     }
                 }
                 .animation(.easeInOut(duration: 0.25), value: self.youtubePlayer.isPlaybackLoading)
+                .animation(.easeInOut(duration: 0.25), value: self.viewModel.membersGate == nil)
                 // "Ad" badge: a server-side (SSAI) ad can still slip past the
                 // blocker; label it so it's clear this isn't the content.
                 .overlay(alignment: .topLeading) {
@@ -545,6 +552,7 @@ struct YouTubeWatchView: View {
 
                     if self.hasPersonalAccount {
                         self.subscribeButton
+                        self.membershipButton
                         self.notificationBellButton
                     }
 
@@ -1000,6 +1008,81 @@ struct YouTubeWatchView: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier(AccessibilityID.YouTubeContent.subscribeButton)
+    }
+
+    /// The channel to open a membership (Join / Abbonati) page for: the watch
+    /// page's parsed owner, falling back to the source card's channel.
+    private var membershipChannelId: String? {
+        self.viewModel.data.channel?.channelId ?? self.video.channelId
+    }
+
+    /// "Join" (Abbonati) button shown next to Subscribe when the channel offers a
+    /// paid membership. Paid flows aren't handled in-app — it opens YouTube.
+    @ViewBuilder
+    private var membershipButton: some View {
+        if self.viewModel.data.channelOffersMembership, let channelId = self.membershipChannelId {
+            self.abbonatiButton(channelId: channelId)
+        }
+    }
+
+    /// The Join / Abbonati capsule that opens the channel's YouTube membership
+    /// page in the browser (no in-app payment flow). Reused by the members-only
+    /// gate card so joining is one click from the blocked video.
+    private func abbonatiButton(channelId: String) -> some View {
+        Button {
+            self.openMembership(channelId: channelId)
+        } label: {
+            Text("Join", comment: "Button to join a channel's paid membership (Abbonati)")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 16)
+                .frame(height: 36)
+                .compatGlass(interactive: true, tint: Self.brandAccent, in: Capsule())
+                .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// Opens the channel's YouTube membership page. Membership/payment is handled
+    /// on YouTube, never in-app.
+    private func openMembership(channelId: String) {
+        guard let url = URL(string: "https://www.youtube.com/channel/\(channelId)/join") else { return }
+        self.openURL(url)
+    }
+
+    /// Members-only gate: replaces the endless spinner for a members-only video
+    /// the signed-in user can't play. Shows YouTube's own dynamic reason /
+    /// subreason plus a Join (Abbonati) action.
+    private func membersGateCard(_ gate: YouTubePlayability) -> some View {
+        ZStack {
+            Rectangle().fill(.black)
+            VStack(spacing: 12) {
+                Image(systemName: "star.circle.fill")
+                    .font(.system(size: 40))
+                    .foregroundStyle(Color(red: 0.18, green: 0.55, blue: 0.34))
+
+                if let reason = gate.reason {
+                    Text(reason)
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+                }
+
+                if let subreason = gate.subreason {
+                    Text(subreason)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.white.opacity(0.7))
+                        .multilineTextAlignment(.center)
+                }
+
+                if let channelId = self.membershipChannelId {
+                    self.abbonatiButton(channelId: channelId)
+                        .padding(.top, 4)
+                }
+            }
+            .padding(.horizontal, 40)
+            .frame(maxWidth: 520)
+        }
     }
 
     /// The subscription notification "bell": a menu to pick the notification

--- a/Tests/KasetTests/YouTubeResponseParserTests.swift
+++ b/Tests/KasetTests/YouTubeResponseParserTests.swift
@@ -388,6 +388,42 @@ struct WatchNextParserTests {
         #expect(watchNext.related.isEmpty)
     }
 
+    @Test("Detects a channel's paid membership from the owner's membershipButton")
+    func detectsChannelMembership() {
+        func data(withMembership: Bool) -> [String: Any] {
+            var owner: [String: Any] = [
+                "title": ["runs": [["text": "Some Channel"]]],
+                "navigationEndpoint": ["browseEndpoint": ["browseId": "UC_channel_123"]],
+            ]
+            if withMembership { owner["membershipButton"] = ["timedAnimationButtonRenderer": [:]] }
+            return ["contents": ["twoColumnWatchNextResults": ["results": ["results": ["contents": [
+                ["videoSecondaryInfoRenderer": ["owner": ["videoOwnerRenderer": owner]]],
+            ]]]]]]
+        }
+        #expect(WatchNextParser.parse(data(withMembership: true)).channelOffersMembership)
+        #expect(!WatchNextParser.parse(data(withMembership: false)).channelOffersMembership)
+    }
+
+    @Test("Members-only gate reads YouTube's reason/subreason and treats OK as playable")
+    func parsesPlayability() {
+        let unplayable: [String: Any] = ["playabilityStatus": [
+            "status": "UNPLAYABLE",
+            "reason": "Video unavailable",
+            "errorScreen": ["playerErrorMessageRenderer": [
+                "reason": ["simpleText": "Members-only video"],
+                "subreason": ["runs": [["text": "Join this channel to get access."]]],
+            ]],
+        ]]
+        let gate = WatchNextParser.playability(unplayable)
+        #expect(!gate.isPlayable)
+        #expect(gate.reason == "Members-only video")
+        #expect(gate.subreason == "Join this channel to get access.")
+
+        // A servable stream (streamingData present) is playable regardless of status text.
+        let ok: [String: Any] = ["playabilityStatus": ["status": "OK"], "streamingData": [:]]
+        #expect(WatchNextParser.playability(ok).isPlayable)
+    }
+
     @Test("Parses canonical chapters and merges macro-marker end bounds")
     func parsesPlayerOverlayChapters() throws {
         let watchNext = WatchNextParser.parse(Self.chapterRendererResponse())


### PR DESCRIPTION
## **User description**
Two related YouTube-membership features.

**A) Members-only gate.** A members-only video a non-member can't watch never gets a stream (YouTube gates it server-side), so the player used to spin forever. For videos already flagged `isMembersOnly` we fetch the `player` endpoint's playabilityStatus and, when UNPLAYABLE, replace the endless spinner with a card showing YouTube's own dynamic reason + subreason plus a Join (Abbonati) button. No bypass — it only surfaces YouTube's notice and links out to join.

**B) Abbonati button.** Channels that offer a paid membership expose a `membershipButton` on their watch-page owner renderer; when present we show a "Join" (it: "Abbonati") button next to Subscribe (Iscriviti) that opens the channel's YouTube membership page. Payment stays on YouTube; nothing in-app.

Tested in the packaged app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add YouTube channel membership actions and clear members-only video access

### What Changed
- Shows a localized “Join” (“Abbonati” in Italian) button next to Subscribe when a channel offers paid memberships.
- Opens the channel’s YouTube membership page for joining and payment.
- Replaces the endless loading spinner on unplayable members-only videos with YouTube’s reason, explanation, and a Join button.
- Keeps playable members-only videos and newly joined memberships working normally.

### Impact
`✅ Clearer members-only access messages`
`✅ One-click channel membership access`
`✅ Fewer endless loading spinners`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
