### PR TITLE
Show the full video title on hover (tooltip)

### DIFF
--- a/Sources/Kaset/Views/YouTube/VideoCard.swift
+++ b/Sources/Kaset/Views/YouTube/VideoCard.swift
@@ -12,14 +12,16 @@ struct VideoCard: View {
             VideoThumbnailView(video: self.video)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(DearrowCache.shared.displayTitle(
-                    for: self.video.videoId, original: self.video.title))
+                Text(self.displayTitle)
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(.primary)
                     // Always reserve two lines so 1- vs 2-line titles don't make
                     // cards in a row different heights (they're top-aligned).
                     .lineLimit(2, reservesSpace: true)
                     .multilineTextAlignment(.leading)
+                    // Long titles truncate to two lines — surface the full title
+                    // as a native hover tooltip.
+                    .help(self.displayTitle)
                     .id("dearrow-\(self.video.videoId)-\(DearrowCache.shared.hasDearrow(for: self.video.videoId))")
 
                 if let channelName = self.video.channelName {
@@ -44,6 +46,10 @@ struct VideoCard: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(self.accessibilityText)
+    }
+
+    private var displayTitle: String {
+        DearrowCache.shared.displayTitle(for: self.video.videoId, original: self.video.title)
     }
 
     private var metaText: String? {

--- a/Sources/Kaset/Views/YouTube/YouTubeListRows.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeListRows.swift
@@ -12,12 +12,15 @@ struct VideoRowView: View {
                 .frame(width: 160)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(DearrowCache.shared.displayTitle(
-                    for: self.video.videoId, original: self.video.title))
+                let displayTitle = DearrowCache.shared.displayTitle(
+                    for: self.video.videoId, original: self.video.title)
+                Text(displayTitle)
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(.primary)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
+                    // Full title as a hover tooltip when truncated.
+                    .help(displayTitle)
 
                 if let channelName = self.video.channelName {
                     Text(channelName)


### PR DESCRIPTION
## **User description**
Long video titles truncate to two lines and end in "…". Add a native macOS hover tooltip (`.help`) surfacing the complete title on video cards (grid / rails) and list rows (search, related), matching YouTube.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Show full YouTube titles when truncated

### What Changed
- Video cards and list rows now show the complete displayed title in a hover tooltip when the title is shortened to two lines
- Tooltips use the same title text shown in the interface, including any available title correction

### Impact
`✅ Full titles available without opening videos`
`✅ Easier identification of truncated videos`
`✅ Consistent title access across cards and list rows`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
