### PR TITLE
⌘R refresh + auto-retry on network loss for video playback

### DIFF
--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -322,6 +322,13 @@ struct KasetApp: App {
                         arbiter: self.playbackArbiter
                     )
                 }
+                .onChange(of: NetworkMonitor.shared.isConnected) { _, isConnected in
+                    // Auto-retry (issue #19): when connectivity returns, revive a
+                    // video that stalled during the outage instead of leaving it stuck.
+                    if isConnected {
+                        self.youtubePlayerService.handleNetworkRestored()
+                    }
+                }
                 .onChange(of: self.playerService.isMiniPlayerVisible) { _, isVisible in
                     self.handleMiniPlayerVisibilityChange(isVisible)
                 }
@@ -449,9 +456,16 @@ struct KasetApp: App {
                 }
                 .keyboardShortcut("s", modifiers: .command)
 
-                // Repeat - ⌘R
+                // Repeat - ⌘⇧R (⌘R is Refresh, below)
                 Button(self.repeatModeLabel) {
                     self.playerService.cycleRepeatMode()
+                }
+                .keyboardShortcut("r", modifiers: [.command, .shift])
+
+                // Refresh video playback - ⌘R. Recovers a stuck/black player
+                // after a network interruption, reloading at the same position.
+                Button(String(localized: "Refresh")) {
+                    self.youtubePlayerService.refreshCurrentVideo()
                 }
                 .keyboardShortcut("r", modifiers: .command)
 

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -605,6 +605,42 @@ final class YouTubePlayerService {
         self.isPlaybackLoading = true
     }
 
+    // MARK: - Refresh (⌘R) & network auto-retry
+
+    /// User-triggered refresh (⌘R): reloads the current video's playback surface
+    /// at its last position, to recover a stuck/black player after a network
+    /// interruption without losing the user's place. No-op when nothing is loaded.
+    ///
+    /// ponytail: a reload autoplays the watch page, so hitting this on a
+    /// deliberately-paused video resumes it — acceptable for a "refresh" action,
+    /// and the auto-retry path below only calls it when playback should be running.
+    func refreshCurrentVideo() {
+        guard let currentVideo = self.currentVideo else { return }
+        self.logger.info("Manual refresh: reloading current video")
+        self.beginYouTubePlaybackIntent()
+        let resumeAt = self.interruptionResumeAt(for: currentVideo.videoId)
+        self.playbackController.prepare(
+            webKitManager: self.webKitManager,
+            playerService: self,
+            usesCookieFreeDataStore: self.usesCookieFreePlaybackDataStore
+        )
+        self.playbackController.reloadVideo(videoId: currentVideo.videoId, resumeAt: resumeAt)
+        self.isPlaybackLoading = true
+    }
+
+    /// Auto-retry when connectivity returns (issue #19): if a video was meant to
+    /// be playing but stalled during a network drop — still "loading", or not
+    /// playing while the user intends to — reload it. Deliberately-paused
+    /// playback is left alone so a network blip never yanks it back to life.
+    func handleNetworkRestored() {
+        guard self.currentVideo != nil else { return }
+        let stalled = self.isPlaybackLoading
+            || (self.desiredPlaybackIntent == .playing && !self.isPlaying)
+        guard stalled else { return }
+        self.logger.info("Network restored: auto-reloading stalled video")
+        self.refreshCurrentVideo()
+    }
+
     /// Returns the best native resume target for an interrupted document.
     /// Native seek intent wins until the observer proves it was applied;
     /// otherwise use the last genuine content clock.

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -218,6 +218,54 @@ struct YouTubePlayerServiceTests {
         #expect(self.controller.reloadedVideoIds.isEmpty)
     }
 
+    @Test("Manual refresh (⌘R) reloads the current video")
+    func refreshReloadsCurrentVideo() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 12, duration: 60, videoId: "abc"))
+
+        self.sut.refreshCurrentVideo()
+
+        // A forced reload of the same id (not a no-op loadVideo). The resume
+        // target is the existing interruption-resume machinery, covered above.
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+    }
+
+    @Test("Manual refresh is a no-op when nothing is playing")
+    func refreshNoOpWhenIdle() {
+        self.sut.refreshCurrentVideo()
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+    }
+
+    @Test("Network restored reloads a stalled (still-loading) video")
+    func networkRestoredReloadsStalledVideo() {
+        // play() leaves the surface loading (no playback update yet) — the
+        // stuck-after-network-drop state.
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        #expect(self.sut.isPlaybackLoading)
+
+        self.sut.handleNetworkRestored()
+
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+    }
+
+    @Test("Network restored leaves a normally-playing video alone")
+    func networkRestoredIgnoresHealthyPlayback() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        // A playback update clears the loading state and marks it playing.
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 5, duration: 60, videoId: "abc"))
+        #expect(!self.sut.isPlaybackLoading)
+
+        self.sut.handleNetworkRestored()
+
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+    }
+
+    @Test("Network restored is a no-op when nothing is playing")
+    func networkRestoredNoOpWhenIdle() {
+        self.sut.handleNetworkRestored()
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+    }
+
     @Test("Identity-switch during an ad resumes the content, not the ad position")
     func reloadDuringAdUsesContentProgress() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))


### PR DESCRIPTION
## **User description**
After a network interruption the video player could stay stuck (black / spinning) with no way to recover.

- **⌘R "Refresh"**: reloads the current video's playback surface at its last position, recovering a stuck player without losing the user's place. ⌘R was Repeat → moved Repeat to **⌘⇧R** (browser-like ⌘R = reload).
- **Auto-retry**: when connectivity returns (`NetworkMonitor`), a video that stalled during the outage reloads automatically. Deliberately-paused playback is left untouched.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Recover video playback after network interruptions

### What Changed
- Added a ⌘R Refresh action that reloads the current video from its last position
- Moved Repeat from ⌘R to ⌘⇧R
- Automatically retries videos that stall during a network outage when connectivity returns
- Leaves videos that the user deliberately paused untouched

### Impact
`✅ Fewer stuck or black video players`
`✅ Playback resumes without losing the viewing position`
`✅ Deliberately paused videos stay paused`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
