### PR TITLE
Integrate upstream #408 playback reliability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,14 @@ Default local workflow is CLI-first: use the commands above for day-to-day verif
 
 > ⚠️ **SwiftFormat `--self insert` rule**: The project uses `--self insert` in `.swiftformat`. In static methods, call other static methods with `Self.methodName()` (not bare `methodName()`); in instance methods, use `self.property` explicitly.
 
+## Localization
+
+> 🌐 **`Sources/Kaset/Resources/Localizable.xcstrings` is the localization source of truth.** Packaged builds compile the catalog directly, but SwiftPM/Xcode runtime builds use the checked-in `Sources/Kaset/Resources/*.lproj/Localizable.strings` mirrors.
+
+- When adding localization keys or changing translations, update the catalog first and update the corresponding checked-in `.lproj/Localizable.strings` files in the same change. Never update only one side.
+- Run `swift test --skip KasetUITests --filter LocalizationCatalogParityTests` after localization changes.
+- When adding a locale, also register its `.lproj` in `Package.swift`, add the `SettingsManager.ContentLanguage` case, and extend localization tests.
+
 ## Debugging & Measurement
 
 > 🔬 **Measure before you fix — never guess at runtime behavior.** For any bug about *timing, lifecycle, or "why didn't this run/load/update"* (SwiftUI `.task`/state churn, cold-launch ordering, perceived latency), instrument the real code path and observe before changing anything. Reasoning about SwiftUI lifecycle or async ordering from the source alone is unreliable; a 10-line timestamped trace settles in one launch what hours of hypothesizing cannot. Add the trace → reproduce → read the evidence → fix the thing the data points at → re-measure to confirm → remove the instrumentation.

--- a/Sources/Kaset/Resources/Localizable.xcstrings
+++ b/Sources/Kaset/Resources/Localizable.xcstrings
@@ -101724,7 +101724,7 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Abbonati a %@"
+            "value" : "Iscriviti a %@"
           }
         },
         "ja" : {
@@ -101909,7 +101909,7 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Abbonati ai podcast su YouTube Music per vederli qui."
+            "value" : "Iscriviti ai podcast su YouTube Music per vederli qui."
           }
         },
         "ja" : {
@@ -102279,7 +102279,7 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Errore nell'abbonamento"
+            "value" : "Errore di iscrizione"
           }
         },
         "ja" : {
@@ -102464,7 +102464,7 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Abbonamenti"
+            "value" : "Iscrizioni"
           }
         },
         "ja" : {

--- a/Sources/Kaset/Resources/it.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/it.lproj/Localizable.strings
@@ -549,11 +549,11 @@
 "Style" = "Stile";
 "Submit" = "Invia";
 "Subscribe" = "Iscriviti";
-"Subscribe %@" = "Abbonati a %@";
-"Subscribe to podcasts on YouTube Music to see them here." = "Abbonati ai podcast su YouTube Music per vederli qui.";
+"Subscribe %@" = "Iscriviti a %@";
+"Subscribe to podcasts on YouTube Music to see them here." = "Iscriviti ai podcast su YouTube Music per vederli qui.";
 "Subscribed" = "Iscritto";
-"Subscription Error" = "Errore nell'abbonamento";
-"Subscriptions" = "Abbonamenti";
+"Subscription Error" = "Errore di iscrizione";
+"Subscriptions" = "Iscrizioni";
 "Suggested" = "Suggerito";
 "Suggested Removals" = "Rimozioni suggerite";
 "Suggestions per insertion" = "Suggerimenti per inserimento";

--- a/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeItemParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeItemParser.swift
@@ -146,9 +146,7 @@ enum YouTubeItemParser {
             return nil
         }
 
-        let sources = (
-            (lockup["thumbnailViewModel"] as? [String: Any])?["image"] as? [String: Any]
-        )?["sources"] as? [[String: Any]]
+        let sources = self.imageSources(fromThumbnailViewModel: lockup["thumbnailViewModel"])
 
         return YouTubeVideo(
             videoId: videoId,
@@ -355,14 +353,31 @@ enum YouTubeItemParser {
     /// wrap it in `collectionThumbnailViewModel.primaryThumbnail` (the stacked
     /// poster), so fall back to that path.
     static func thumbnailURL(fromLockup lockup: [String: Any]) -> URL? {
-        let contentImage = lockup["contentImage"] as? [String: Any]
-        let thumbnailViewModel = contentImage?["thumbnailViewModel"] as? [String: Any]
-            ?? ((contentImage?["collectionThumbnailViewModel"] as? [String: Any])?["primaryThumbnail"]
-                as? [String: Any])?["thumbnailViewModel"] as? [String: Any]
-        let sources = (thumbnailViewModel?["image"] as? [String: Any])?["sources"]
-            as? [[String: Any]]
-        guard let sources else { return nil }
+        guard let contentImage = lockup["contentImage"] as? [String: Any] else { return nil }
+
+        if let sources = self.imageSources(fromThumbnailViewModel: contentImage["thumbnailViewModel"]) {
+            return self.bestSourceURL(from: sources)
+        }
+
+        // Playlist and album lockups stack their poster behind a collection wrapper.
+        let collection = contentImage["collectionThumbnailViewModel"] as? [String: Any]
+        guard let sources = self.imageSources(
+            fromThumbnailViewModel: collection?["primaryThumbnail"]
+        ) else {
+            return nil
+        }
         return self.bestSourceURL(from: sources)
+    }
+
+    /// Extracts `image.sources` from a `thumbnailViewModel`, tolerating the
+    /// singly-nested form InnerTube uses for Shorts and collection lockups.
+    static func imageSources(fromThumbnailViewModel value: Any?) -> [[String: Any]]? {
+        guard let container = value as? [String: Any] else { return nil }
+        if let sources = (container["image"] as? [String: Any])?["sources"] as? [[String: Any]] {
+            return sources
+        }
+        let nested = container["thumbnailViewModel"] as? [String: Any]
+        return (nested?["image"] as? [String: Any])?["sources"] as? [[String: Any]]
     }
 
     /// Picks the largest entry from an array of `{url, width, height}` sources,

--- a/Sources/Kaset/Services/Player/WebPlaybackDocumentGeneration.swift
+++ b/Sources/Kaset/Services/Player/WebPlaybackDocumentGeneration.swift
@@ -352,6 +352,14 @@ struct WebPlaybackDocumentGeneration: Equatable {
         return host == playbackHost.lowercased() || Self.trustedRedirectHosts.contains(host)
     }
 
+    // Google's "unusual traffic" challenge (`www.google.com/sorry/…`) is
+    // deliberately NOT trusted here. Allowing the URL alone does not make it
+    // reachable: the challenge is commonly served as HTTP 429, which
+    // `acceptsMainFrameResponse` rejects before commit, and clearing it posts
+    // `g-recaptcha-response` as a form body that `requestByBindingGeneration`
+    // cannot carry across a generation rebind. Supporting it needs both of
+    // those handled together.
+
     static func isTrustedIntermediaryURL(_ url: URL?) -> Bool {
         guard let url,
               url.scheme?.lowercased() == "https",
@@ -382,6 +390,31 @@ struct WebPlaybackDocumentGeneration: Equatable {
         }
         return committedIntermediaryGeneration == generation
             && Self.isAllowedPlaybackNavigationURL(currentURL, playbackHost: playbackHost)
+    }
+
+    /// A form submission from a committed trusted intermediary must keep the
+    /// original WebKit navigation so its HTTP body is preserved. GET
+    /// continuations can be rebound with a generation token, but WebKit omits
+    /// form bodies from the navigation-policy request used to reconstruct them.
+    static func shouldAllowTrustedIntermediaryFormSubmission(
+        _ request: URLRequest,
+        currentURL: URL?,
+        generation: UInt64,
+        playbackHost: String,
+        committedIntermediaryGeneration: UInt64?
+    ) -> Bool {
+        guard request.httpMethod?.uppercased() == "POST",
+              committedIntermediaryGeneration == generation,
+              self.isTrustedIntermediaryURL(currentURL),
+              self.isTrustedIntermediaryURL(request.url),
+              Self.generation(from: request.url) == nil
+        else { return false }
+
+        let mainDocumentGeneration = Self.generation(from: request.mainDocumentURL)
+        guard mainDocumentGeneration == nil || mainDocumentGeneration == generation else {
+            return false
+        }
+        return Self.isAllowedPlaybackNavigationURL(request.url, playbackHost: playbackHost)
     }
 
     static func requestByBindingGeneration(

--- a/Sources/Kaset/Services/Player/YouTubePlayerService+Seeking.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService+Seeking.swift
@@ -36,10 +36,15 @@ extension YouTubePlayerService {
         guard time.isFinite else { return }
         self.invalidateExplicitStartTargetForUserSeek()
         let target = self.clampedSeekTarget(time)
-        // A live stream never "ends" when you catch up to the edge — seeking to
-        // the end of the DVR window just parks at the live head, so don't treat
-        // it as a completed watch (which would pause the stream).
-        if !self.isLive, self.duration > 0, target >= self.duration - Self.seekToEndThreshold {
+        // A live stream's duration is its DVR window, not a finish line, so
+        // seeking to the edge must not count as watching to the end. Runtime
+        // bridge state covers URL launches and SPA drift whose feed model did
+        // not carry liveness.
+        if self.currentVideo?.isLive != true,
+           !self.currentMediaIsLive,
+           self.duration > 0,
+           target >= self.duration - Self.seekToEndThreshold
+        {
             self.handleManualSeekToEnd()
             return
         }

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -1614,10 +1614,9 @@ extension YouTubePlayerService {
             self.isAtLiveEdge = update.isAtLiveEdge
         }
         // Runtime liveness from the bound media element (URL launches, SPA drift
-        // whose feed model lacked liveness). The loading spinner is now cleared
-        // by `finishPlaybackLoadingIfReady` and media errors handled by
-        // `deferMediaErrorIfNeeded` from the STATE_UPDATE handler (#408), rather
-        // than by a `duration > 0` proxy here.
+        // whose feed model lacked liveness). The loading spinner is cleared by
+        // `finishPlaybackLoadingIfReady` and media errors handled by
+        // `deferMediaErrorIfNeeded` from the STATE_UPDATE handler (#408).
         if !update.isAd,
            update.hasReadyMedia,
            let metadataVideoId = update.videoId,
@@ -1632,8 +1631,28 @@ extension YouTubePlayerService {
     }
 
     private func finishPlaybackLoadingIfReady(_ update: PlaybackUpdate) {
-        guard self.readyMediaBelongsToCurrentPlayback(update) else { return }
+        guard self.readyMediaBelongsToCurrentPlayback(update)
+            || self.metadataReadyForCurrentPlayback(update)
+        else { return }
         self.finishPlaybackLoading()
+    }
+
+    /// The fork's original loading-finish signal: a known duration means metadata
+    /// loaded and a frame is imminent. Kept alongside #408's stricter ready-media
+    /// check so surfaces that gate on `isPlaybackLoading` — notably the Shorts
+    /// thumbnail cover — still clear when a video reports its duration before the
+    /// bridge flags ready media. Ads and media-error frames are excluded so the
+    /// ad surface and error recovery are unaffected.
+    private func metadataReadyForCurrentPlayback(_ update: PlaybackUpdate) -> Bool {
+        guard update.duration > 0, !update.hasMediaError, !update.isAd,
+              let currentVideoId = self.currentVideo?.videoId
+        else { return false }
+        // The first frames may not have bound the media id yet; accept a matching
+        // or not-yet-known id, but never another video's snapshot.
+        if let boundVideoId = update.boundVideoId, boundVideoId != currentVideoId {
+            return false
+        }
+        return update.videoId == nil || update.videoId == currentVideoId
     }
 
     private func readyMediaBelongsToCurrentPlayback(_ update: PlaybackUpdate) -> Bool {

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -208,6 +208,13 @@ final class YouTubePlayerService {
     /// Whether the current video is waiting for the WebView to report playable media.
     private(set) var isPlaybackLoading = false
 
+    /// Runtime liveness from the active media element. This covers videos whose
+    /// feed model is incomplete, including URL launches and SPA drift.
+    @ObservationIgnored var currentMediaIsLive = false
+
+    @ObservationIgnored private var playbackLoadingTimeoutTask: Task<Void, Never>?
+    @ObservationIgnored private var playbackLoadingGeneration: UInt64 = 0
+
     /// SponsorBlock segments for the current video ([start, end] in seconds, by category).
     /// Updated by the WebView observer when segments are fetched from the SponsorBlock API.
     var sponsorSegments: [SponsorSegment] = []
@@ -483,6 +490,7 @@ final class YouTubePlayerService {
     private let webKitManager: WebKitManager
     let playbackController: any YouTubeWatchPlaybackControlling
     private var usesCookieFreePlaybackDataStore = false
+    private let playbackLoadingTimeout: Duration
     private let logger = DiagnosticsLogger.player
 
     /// Whether a playing video should pop out into the floating window when the
@@ -494,11 +502,13 @@ final class YouTubePlayerService {
     init(
         webKitManager: WebKitManager = .shared,
         playbackController: (any YouTubeWatchPlaybackControlling)? = nil,
-        shouldPopOutOnNavigateAway: @escaping @MainActor () -> Bool = { SettingsManager.shared.popOutVideoOnNavigateAway }
+        shouldPopOutOnNavigateAway: @escaping @MainActor () -> Bool = { SettingsManager.shared.popOutVideoOnNavigateAway },
+        playbackLoadingTimeout: Duration = .seconds(15)
     ) {
         self.webKitManager = webKitManager
         self.playbackController = playbackController ?? YouTubeWatchWebView.shared
         self.shouldPopOutOnNavigateAway = shouldPopOutOnNavigateAway
+        self.playbackLoadingTimeout = playbackLoadingTimeout
     }
 
     // MARK: - Commands
@@ -532,7 +542,7 @@ final class YouTubePlayerService {
                 seconds: normalizedStartAt
             )
         }
-        self.isPlaybackLoading = true
+        self.beginPlaybackLoading()
         self.surfaceLocation = .inline
 
         // Create the WebView on demand; containers reparent it on appear.
@@ -602,7 +612,7 @@ final class YouTubePlayerService {
             resumeAt: resumeAt
         )
         self.isIdentityReloadInFlight = true
-        self.isPlaybackLoading = true
+        self.beginPlaybackLoading()
     }
 
     // MARK: - Refresh (⌘R) & network auto-retry
@@ -725,7 +735,7 @@ final class YouTubePlayerService {
             self.autoplayRecoveryRequestGeneration &+= 1
             self.isPlaying = false
             self.isIdentityReloadInFlight = false
-            self.isPlaybackLoading = false
+            self.finishPlaybackLoading()
             self.hasObservedPausedMedia = true
             return
         }
@@ -738,14 +748,14 @@ final class YouTubePlayerService {
             self.userUpdatedPendingPausedIdentityReloadSeek = false
             self.isIdentityReloadInFlight = false
             self.isPlaying = false
-            self.isPlaybackLoading = false
+            self.finishPlaybackLoading()
             return
         }
 
         self.playbackController.reloadVideo(videoId: currentVideo.videoId, resumeAt: resumeAt)
         self.isPlaying = false
         self.isIdentityReloadInFlight = true
-        self.isPlaybackLoading = true
+        self.beginPlaybackLoading()
     }
 
     /// Leaves a failed watch-page navigation in an explicitly retryable paused
@@ -770,9 +780,15 @@ final class YouTubePlayerService {
         self.userUpdatedPendingPausedIdentityReloadSeek = false
         self.isIdentityReloadInFlight = false
         self.desiredPlaybackIntent = .paused
+        // A navigation may have finished before its media became ready, leaving
+        // no tracked load for the controller to cancel. Keep late playing
+        // samples from re-authorizing that document or consuming the deferred
+        // reload before an explicit user resume.
+        self.isExplicitPauseIntentActive = true
         self.isAwaitingResumeConfirmation = false
+        self.hasObservedPausedMedia = true
         self.isPlaying = false
-        self.isPlaybackLoading = false
+        self.finishPlaybackLoading()
     }
 
     /// Toggles play/pause.
@@ -874,7 +890,7 @@ final class YouTubePlayerService {
         self.desiredPlaybackIntent = .playing
         self.isExplicitPauseIntentActive = false
         self.isIdentityReloadInFlight = true
-        self.isPlaybackLoading = true
+        self.beginPlaybackLoading()
         return true
     }
 
@@ -913,7 +929,7 @@ final class YouTubePlayerService {
             self.isIdentityReloadInFlight = false
         }
         self.isPlaying = false
-        self.isPlaybackLoading = false
+        self.finishPlaybackLoading()
     }
 
     /// Stops playback entirely and releases the surface.
@@ -943,7 +959,7 @@ final class YouTubePlayerService {
         self.isExplicitPauseIntentActive = true
         self.isAwaitingResumeConfirmation = false
         self.isPlaying = false
-        self.isPlaybackLoading = false
+        self.finishPlaybackLoading()
         self.isIdentityReloadInFlight = false
         self.progress = 0
         self.duration = 0
@@ -1079,7 +1095,7 @@ final class YouTubePlayerService {
         self.currentWatchConcluded = false
         self.isIdentityReloadInFlight = false
         self.resetPerVideoState()
-        self.isPlaybackLoading = true
+        self.beginPlaybackLoading()
         self.playbackController.prepare(
             webKitManager: self.webKitManager,
             playerService: self,
@@ -1144,6 +1160,8 @@ final class YouTubePlayerService {
         self.activeCaptionLanguageCode = nil
         self.qualityLevels = []
         self.currentQuality = nil
+        self.userPinnedQuality = nil
+        self.currentMediaIsLive = false
         self.storyboardSpec = nil
         self.sponsorSegments = []
         self.dismissSponsorBlockSkipNotice()
@@ -1208,7 +1226,12 @@ final class YouTubePlayerService {
             guard self.currentVideo?.videoId == videoId else { return }
 
             self.captionTracks = tracks
-            self.qualityLevels = await self.playbackController.availableQualityLevels()
+            let levels = await self.playbackController.availableQualityLevels()
+            // The player accepts "auto" even when it does not advertise it, and
+            // the menu needs that row to represent an unpinned quality.
+            self.qualityLevels = levels.isEmpty || levels.contains("auto")
+                ? levels
+                : levels + ["auto"]
             self.currentQuality = await self.playbackController.currentQualityLevel()
             self.activeCaptionLanguageCode = await self.playbackController.currentCaptionLanguageCode()
 
@@ -1317,6 +1340,41 @@ final class YouTubePlayerService {
     /// source: the inline surface pauses in place (no pop-out window) and
     /// the restored watch view re-adopts it when the user comes back.
     private var pauseInPlaceOnDisappear = false
+}
+
+extension YouTubePlayerService {
+    private func beginPlaybackLoading() {
+        self.playbackLoadingTimeoutTask?.cancel()
+        self.playbackLoadingGeneration &+= 1
+        let loadingGeneration = self.playbackLoadingGeneration
+        self.isPlaybackLoading = true
+
+        let timeout = self.playbackLoadingTimeout
+        let videoId = self.currentVideo?.videoId
+        self.playbackLoadingTimeoutTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: timeout)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled,
+                  let self,
+                  self.playbackLoadingGeneration == loadingGeneration,
+                  self.isPlaybackLoading,
+                  self.currentVideo?.videoId == videoId
+            else { return }
+            if !self.playbackController.cancelPendingLoad() {
+                self.deferCurrentVideoReload()
+            }
+        }
+    }
+
+    private func finishPlaybackLoading() {
+        self.playbackLoadingGeneration &+= 1
+        self.isPlaybackLoading = false
+        self.playbackLoadingTimeoutTask?.cancel()
+        self.playbackLoadingTimeoutTask = nil
+    }
 
     /// Prepares the inline surface for a switch to the music source:
     /// pause in place, keep everything loaded for restore.
@@ -1355,9 +1413,7 @@ final class YouTubePlayerService {
             self.stop()
         }
     }
-}
 
-extension YouTubePlayerService {
     // MARK: - Bridge Callbacks
 
     /// A `STATE_UPDATE` payload from the watch page observer script.
@@ -1366,6 +1422,7 @@ extension YouTubePlayerService {
         let progress: Double
         let duration: Double
         var hasReadyMedia = false
+        var hasMediaError = false
         var videoId: String?
         var boundVideoId: String?
         var title: String?
@@ -1431,6 +1488,8 @@ extension YouTubePlayerService {
         self.reopenConcludedWatchIfNeeded(update, effectiveIsPlaying: effectiveIsPlaying)
         self.refreshPlaybackMetadataIfNeeded(update, effectiveIsPlaying: effectiveIsPlaying)
         self.followPageDriftIfNeeded(update)
+        self.finishPlaybackLoadingIfReady(update)
+        self.deferMediaErrorIfNeeded(update)
         self.completeAutoplayTransitionIfNeeded(update)
         self.recordReadyContentProgressIfPossible(update)
 
@@ -1554,13 +1613,58 @@ extension YouTubePlayerService {
         if self.isAtLiveEdge != update.isAtLiveEdge {
             self.isAtLiveEdge = update.isAtLiveEdge
         }
-        // Keep the loading spinner up until the video actually has media — the
-        // first STATE_UPDATE arrives while the <video> is still at 0:00 with no
-        // frame, so clearing then leaves a black gap after the spinner vanishes.
-        // A known duration means metadata loaded and a frame is imminent.
-        if self.isPlaybackLoading, update.duration > 0 {
-            self.isPlaybackLoading = false
+        // Runtime liveness from the bound media element (URL launches, SPA drift
+        // whose feed model lacked liveness). The loading spinner is now cleared
+        // by `finishPlaybackLoadingIfReady` and media errors handled by
+        // `deferMediaErrorIfNeeded` from the STATE_UPDATE handler (#408), rather
+        // than by a `duration > 0` proxy here.
+        if !update.isAd,
+           update.hasReadyMedia,
+           let metadataVideoId = update.videoId,
+           update.boundVideoId == metadataVideoId
+        {
+            let resolvedIsLive = update.isLive || self.currentVideo?.isLive == true
+            self.currentMediaIsLive = resolvedIsLive
+            if resolvedIsLive {
+                self.updateCurrentVideoLiveness(true, videoId: metadataVideoId)
+            }
         }
+    }
+
+    private func finishPlaybackLoadingIfReady(_ update: PlaybackUpdate) {
+        guard self.readyMediaBelongsToCurrentPlayback(update) else { return }
+        self.finishPlaybackLoading()
+    }
+
+    private func readyMediaBelongsToCurrentPlayback(_ update: PlaybackUpdate) -> Bool {
+        guard update.hasReadyMedia, !update.hasMediaError else { return false }
+        // Preroll and midroll ads use the selected video's media element and are
+        // sufficient to replace the initial black loading surface, but a queued
+        // ad snapshot from outgoing media must not finish a newer video's load.
+        if update.isAd {
+            return update.boundVideoId == self.currentVideo?.videoId
+        }
+        guard let currentVideoId = self.currentVideo?.videoId else { return false }
+        return update.videoId == currentVideoId && update.boundVideoId == currentVideoId
+    }
+
+    private func deferMediaErrorIfNeeded(_ update: PlaybackUpdate) {
+        guard self.mediaErrorBelongsToCurrentContent(update) else { return }
+        self.deferCurrentVideoReload()
+    }
+
+    private func mediaErrorBelongsToCurrentContent(_ update: PlaybackUpdate) -> Bool {
+        guard update.hasMediaError,
+              !update.isAd,
+              let currentVideoId = self.currentVideo?.videoId
+        else { return false }
+
+        if let boundVideoId = update.boundVideoId,
+           boundVideoId != currentVideoId
+        {
+            return false
+        }
+        return update.videoId == nil || update.videoId == currentVideoId
     }
 
     private func reopenConcludedWatchIfNeeded(
@@ -1671,14 +1775,28 @@ extension YouTubePlayerService {
         // Preserve any SponsorBlock segments already fetched for the drifted-to
         // video (fork feature): reset per-video state without clobbering pending
         // SponsorBlock state, then reapply it for the new video id.
+        let driftedIsLive = update.hasReadyMedia
+            && update.boundVideoId == videoId
+            && update.isLive
         self.resetPerVideoState(preservingPendingSponsorBlockState: true)
+        self.currentMediaIsLive = driftedIsLive
         self.currentVideo = YouTubeVideo(
             videoId: videoId,
             title: update.title ?? current.title,
             channelName: current.channelName,
-            channelId: current.channelId
+            channelId: current.channelId,
+            isLive: driftedIsLive
         )
         self.applyPendingSponsorBlockState(for: videoId)
+        let readyMediaBelongsToDriftedVideo = update.hasReadyMedia
+            && !update.hasMediaError
+            && update.boundVideoId == videoId
+        if !readyMediaBelongsToDriftedVideo {
+            // The previous timeout was keyed to the outgoing video. Start a
+            // fresh bound for the drifted document so an empty replacement
+            // cannot strand loading indefinitely.
+            self.beginPlaybackLoading()
+        }
         if let driftedContentProgress {
             self.lastNonAdContentProgress = driftedContentProgress
             self.lastNonAdContentVideoId = videoId
@@ -1708,6 +1826,27 @@ extension YouTubePlayerService {
             self.lastNonAdContentProgress = update.progress
             self.lastNonAdContentVideoId = boundVideoId
         }
+    }
+
+    private func updateCurrentVideoLiveness(_ isLive: Bool, videoId: String?) {
+        guard let videoId,
+              let current = self.currentVideo,
+              current.videoId == videoId,
+              current.isLive != isLive
+        else { return }
+        self.currentVideo = YouTubeVideo(
+            videoId: current.videoId,
+            title: current.title,
+            channelName: current.channelName,
+            channelId: current.channelId,
+            lengthText: current.lengthText,
+            viewCountText: current.viewCountText,
+            publishedText: current.publishedText,
+            thumbnailURL: current.thumbnailURL,
+            isLive: isLive,
+            isShort: current.isShort,
+            watchedPercent: current.watchedPercent
+        )
     }
 
     private func reconciledPlayingState(for update: PlaybackUpdate) -> (
@@ -1823,7 +1962,7 @@ extension YouTubePlayerService {
         self.lastResumeIssuedAtMilliseconds = nil
         self.pendingExplicitStartTarget = nil
         self.pendingUserSeekTarget = nil
-        self.isPlaybackLoading = false
+        self.finishPlaybackLoading()
         // A finish changes watch history (the video crosses into "finished"), so
         // signal it — this lets Home drop a just-finished video from Continue
         // Watching even when the video ended in the floating window while the

--- a/Sources/Kaset/Views/YouTube/ScrollForwardingWebView.swift
+++ b/Sources/Kaset/Views/YouTube/ScrollForwardingWebView.swift
@@ -15,11 +15,12 @@ final class ScrollForwardingWebView: WKWebView {
             super.scrollWheel(with: event)
             return
         }
-        if let scrollView = self.enclosingScrollView {
-            scrollView.scrollWheel(with: event)
-        } else {
-            self.nextResponder?.scrollWheel(with: event)
-        }
+        // Forward down the responder chain rather than to `enclosingScrollView`:
+        // this fork hosts the surface inside a SwiftUI ScrollView whose backing
+        // scroller a direct call bypasses, adding scroll lag on the watch page.
+        // The next responder reaches the right scroller smoothly (the fork's
+        // long-standing behaviour).
+        self.nextResponder?.scrollWheel(with: event)
     }
 
     /// Only the extracted watch document is unscrollable. A revealed

--- a/Sources/Kaset/Views/YouTube/ScrollForwardingWebView.swift
+++ b/Sources/Kaset/Views/YouTube/ScrollForwardingWebView.swift
@@ -1,0 +1,32 @@
+import WebKit
+
+// MARK: - ScrollForwardingWebView
+
+/// A WebView that hands scroll-wheel events to the view behind it.
+///
+/// The extracted watch document is `overflow: hidden`, so it has nothing to
+/// scroll and simply swallows the event. Inside the watch page's `ScrollView`
+/// that turns the whole video surface into a dead zone. Forwarding restores
+/// scrolling over the video while leaving clicks (play/pause, the player
+/// chrome) with the WebView — an overlay would intercept those too.
+final class ScrollForwardingWebView: WKWebView {
+    override func scrollWheel(with event: NSEvent) {
+        guard self.forwardsScrollWheel else {
+            super.scrollWheel(with: event)
+            return
+        }
+        if let scrollView = self.enclosingScrollView {
+            scrollView.scrollWheel(with: event)
+        } else {
+            self.nextResponder?.scrollWheel(with: event)
+        }
+    }
+
+    /// Only the extracted watch document is unscrollable. A revealed
+    /// interstitial (consent, CAPTCHA, sign-in) is an ordinary page that can
+    /// be taller than the viewport, so it has to keep its own wheel handling
+    /// or its controls become unreachable.
+    private var forwardsScrollWheel: Bool {
+        !WebPlaybackDocumentGeneration.isTrustedIntermediaryURL(self.url)
+    }
+}

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchSurfaceView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchSurfaceView.swift
@@ -7,6 +7,18 @@ import WebKit
 /// native view. Used by both the inline WatchView and the floating window;
 /// whichever is on screen reparents the singleton WebView into itself.
 struct YouTubeWatchSurfaceView: NSViewRepresentable {
+    @Environment(YouTubePlayerService.self) private var youtubePlayer
+
+    /// When present, this host may claim the singleton WebView only while that
+    /// video is still selected. Shorts pages overlap briefly during paging, so
+    /// an outgoing page can otherwise update late and steal the WebView back
+    /// from the newly active page.
+    let expectedVideoId: String?
+
+    init(expectedVideoId: String? = nil) {
+        self.expectedVideoId = expectedVideoId
+    }
+
     func makeNSView(context _: Context) -> YouTubeWatchContainerView {
         let container = YouTubeWatchContainerView()
         container.wantsLayer = true
@@ -15,7 +27,32 @@ struct YouTubeWatchSurfaceView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: YouTubeWatchContainerView, context _: Context) {
-        YouTubeWatchWebView.shared.ensureInHierarchy(container: nsView)
+        YouTubeWatchWebView.shared.ensureInHierarchy(
+            container: nsView,
+            expectedVideoId: self.expectedVideoId,
+            selectedVideoId: self.youtubePlayer.currentVideo?.videoId
+        )
+    }
+}
+
+// MARK: - YouTubeWatchSurfaceAttachment
+
+@MainActor
+enum YouTubeWatchSurfaceAttachment {
+    @discardableResult
+    static func claim(
+        surface: NSView,
+        in container: NSView,
+        expectedVideoId: String?,
+        currentVideoId: String?
+    ) -> Bool {
+        if let expectedVideoId, expectedVideoId != currentVideoId {
+            return false
+        }
+        guard surface.superview !== container else { return true }
+        surface.removeFromSuperview()
+        container.addSubview(surface)
+        return true
     }
 }
 

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Coordinator.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Coordinator.swift
@@ -1,5 +1,7 @@
 import WebKit
 
+// MARK: - YouTubeWatchWebView.Coordinator
+
 extension YouTubeWatchWebView {
     // MARK: - Coordinator
 
@@ -96,6 +98,7 @@ extension YouTubeWatchWebView {
                 progress: body["progress"] as? Double ?? 0,
                 duration: body["duration"] as? Double ?? 0,
                 hasReadyMedia: body["hasReadyMedia"] as? Bool ?? false,
+                hasMediaError: body["hasMediaError"] as? Bool ?? false,
                 videoId: (body["videoId"] as? String).flatMap { $0.isEmpty ? nil : $0 },
                 boundVideoId: (body["boundVideoId"] as? String)
                     .flatMap { $0.isEmpty ? nil : $0 },
@@ -294,27 +297,18 @@ extension YouTubeWatchWebView {
             }
             YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewDidFinishNavigation(webView)
 
-            // If YouTube served something other than a watch page — Google's
-            // "/sorry/" unusual-traffic CAPTCHA or the EU consent interstitial —
-            // our chrome-hiding extraction would leave it invisible and the video
-            // stuck "loading". Reveal the page so the user can actually solve it.
-            if let url = webView.url?.absoluteString,
-               url.contains("google.com/sorry") || url.contains("/sorry/")
-               || url.contains("consent.youtube") || url.contains("consent.google")
-            {
+            // A trusted interstitial (consent, sign-in) is allowed to commit
+            // here so the user can read and act on it, but the document-start
+            // blackout leaves it invisible and un-hit-testable. Reveal it and
+            // clear the loading state so it isn't stuck behind the spinner, then
+            // fall through — it is not a playback URL, so the guard below returns.
+            //
+            // Trusted same-generation form POSTs are admitted unchanged by the
+            // navigation policy so their bodies survive; subsequent GET
+            // continuations are rebound with the generation token as before.
+            if WebPlaybackDocumentGeneration.isTrustedIntermediaryURL(webView.url) {
                 webView.evaluateJavaScript(
-                    """
-                    (function() {
-                        try { if (window.__kasetStopYTExtraction) { window.__kasetStopYTExtraction(); } } catch (e) {}
-                        ['kaset-yt-blackout', 'kaset-yt-video-style'].forEach(function(id) {
-                            var el = document.getElementById(id);
-                            if (el) { el.remove(); }
-                        });
-                        var s = document.createElement('style');
-                        s.textContent = 'html, body, * { visibility: visible !important; }';
-                        document.documentElement.appendChild(s);
-                    })();
-                    """,
+                    YouTubeWatchWebView.revealInterstitialScript,
                     completionHandler: nil
                 )
                 self.playerService.clearPlaybackLoadingForInterstitial()
@@ -340,8 +334,20 @@ extension YouTubeWatchWebView {
                 """
                 (function() {
                     window.__kasetTargetVolume = \(savedVolume);
-                    const video = document.querySelector('video');
-                    if (video) { video.volume = \(savedVolume); }
+                    if (typeof window.__kasetApplyTargetVolumeToAllMedia === 'function') {
+                        window.__kasetApplyTargetVolumeToAllMedia();
+                    } else {
+                        const video = document.querySelector('video');
+                        if (video) {
+                            if (\(savedVolume) <= 0) {
+                                video.muted = true;
+                                video.volume = 0;
+                            } else {
+                                video.volume = \(savedVolume);
+                                video.muted = false;
+                            }
+                        }
+                    }
                     if (window.__kasetExtractVideo) { window.__kasetExtractVideo(); }
                 })();
                 """,
@@ -365,5 +371,99 @@ extension YouTubeWatchWebView {
                 resumeAtOverride: resumeAt
             )
         }
+    }
+}
+
+extension YouTubeWatchWebView {
+    func decideNavigationPolicy(
+        webView: WKWebView,
+        navigationAction: WKNavigationAction,
+        decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
+    ) {
+        guard navigationAction.targetFrame?.isMainFrame == true else {
+            decisionHandler(.allow)
+            return
+        }
+
+        if WebPlaybackDocumentGeneration.isInternalBlankNavigation(navigationAction.request.url) {
+            decisionHandler(
+                self.documentGeneration.ownsBlankNavigation(navigationAction.request.url)
+                    ? .allow
+                    : .cancel
+            )
+            return
+        }
+
+        if WebPlaybackDocumentGeneration.isFragmentOnlyNavigation(
+            from: webView.url,
+            to: navigationAction.request.url
+        ) {
+            self.webKitManager?.extensionHostWebViewWillNavigate(
+                webView,
+                to: navigationAction.request.url
+            )
+            decisionHandler(.allow)
+            return
+        }
+
+        if self.documentGeneration.pendingGeneration != nil {
+            decisionHandler(.cancel)
+            return
+        }
+
+        if let inFlightGeneration = self.documentGeneration.inFlightGeneration {
+            guard WebPlaybackDocumentGeneration.requestBelongsToNavigationChain(
+                navigationAction.request,
+                currentURL: webView.url,
+                generation: inFlightGeneration,
+                playbackHost: "www.youtube.com",
+                committedIntermediaryGeneration: self.documentGeneration.committedIntermediaryGeneration
+            ) else {
+                decisionHandler(.cancel)
+                return
+            }
+            if WebPlaybackDocumentGeneration.generation(from: navigationAction.request.url)
+                != inFlightGeneration
+            {
+                if WebPlaybackDocumentGeneration.shouldAllowTrustedIntermediaryFormSubmission(
+                    navigationAction.request,
+                    currentURL: webView.url,
+                    generation: inFlightGeneration,
+                    playbackHost: "www.youtube.com",
+                    committedIntermediaryGeneration: self.documentGeneration
+                        .committedIntermediaryGeneration
+                ) {
+                    self.webKitManager?.extensionHostWebViewWillNavigate(
+                        webView,
+                        to: navigationAction.request.url
+                    )
+                    decisionHandler(.allow)
+                    return
+                }
+                decisionHandler(.cancel)
+                self.continuationGenerationsAwaitingStart.insert(inFlightGeneration)
+                if let boundRequest = WebPlaybackDocumentGeneration.requestByBindingGeneration(
+                    navigationAction.request,
+                    generation: inFlightGeneration
+                ) {
+                    Task { @MainActor in
+                        self.startBoundNavigationContinuation(
+                            on: webView,
+                            request: boundRequest,
+                            generation: inFlightGeneration
+                        )
+                    }
+                }
+                return
+            }
+            self.webKitManager?.extensionHostWebViewWillNavigate(
+                webView,
+                to: navigationAction.request.url
+            )
+            decisionHandler(.allow)
+            return
+        }
+
+        decisionHandler(.cancel)
     }
 }

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+DocumentGeneration.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+DocumentGeneration.swift
@@ -40,6 +40,7 @@ extension YouTubeWatchWebView {
         })();
         window.__kasetTargetVolume = \(clamped);
         window.__kasetNativePausePending = false;
+        \(Self.documentStartAudioGuardScript(targetVolume: clamped))
         """
         if let pendingSeek, pendingSeek.isFinite, pendingSeek >= 0 {
             let attemptID = pendingSeekAttemptID ?? 1
@@ -86,6 +87,188 @@ extension YouTubeWatchWebView {
 
         return script
     }
+
+    // swiftlint:disable function_body_length
+    /// Installs an audio gate before YouTube creates or autoplays its media.
+    ///
+    /// Merely storing `__kasetTargetVolume` at document start leaves a race: a
+    /// newly created video can begin at YouTube's persisted volume before the
+    /// document-end observer attaches. This gate applies the target at the
+    /// `HTMLMediaElement.play()` boundary, covers native autoplay via capture
+    /// listeners, and immediately protects replacement media elements.
+    nonisolated static func documentStartAudioGuardScript(targetVolume: Double) -> String {
+        let clamped = targetVolume.isFinite ? min(max(targetVolume, 0), 1) : 1.0
+        return """
+        (function() {
+            'use strict';
+            window.__kasetTargetVolume = \(clamped);
+
+            function resolvedTarget() {
+                const target = window.__kasetTargetVolume;
+                return typeof target === 'number' && Number.isFinite(target)
+                    ? Math.min(Math.max(target, 0), 1)
+                    : 1;
+            }
+
+            function applyPlayerTarget(target) {
+                const player = document.getElementById('movie_player');
+                if (!player) { return; }
+
+                const percent = Math.round(target * 100);
+                const lastTarget = window.__kasetLastAppliedPlayerVolume;
+                let volumeMismatch = lastTarget !== target;
+                if (typeof player.getVolume === 'function') {
+                    try {
+                        const currentVolume = Number(player.getVolume());
+                        if (Number.isFinite(currentVolume)) {
+                            volumeMismatch = Math.abs(currentVolume - percent) > 1;
+                        }
+                    } catch (e) {}
+                }
+
+                let muteMismatch = lastTarget !== target;
+                if (typeof player.isMuted === 'function') {
+                    try {
+                        const currentMuted = player.isMuted();
+                        if (typeof currentMuted === 'boolean') {
+                            muteMismatch = currentMuted !== (target <= 0);
+                        }
+                    } catch (e) {}
+                }
+
+                try {
+                    if (target <= 0 && muteMismatch && typeof player.mute === 'function') {
+                        player.mute();
+                    }
+                    if (volumeMismatch && typeof player.setVolume === 'function') {
+                        player.setVolume(percent);
+                    }
+                    if (target > 0 && muteMismatch && typeof player.unMute === 'function') {
+                        player.unMute();
+                    }
+                    window.__kasetLastAppliedPlayerVolume = target;
+                } catch (e) {}
+            }
+
+            function applyTarget(media) {
+                if (!media || typeof media.volume !== 'number') { return; }
+                const target = resolvedTarget();
+                try {
+                    if (target <= 0) {
+                        // Mute first so lowering volume can never expose an audible frame.
+                        if (!media.muted) { media.muted = true; }
+                        if (Math.abs(media.volume) > 0.001) { media.volume = 0; }
+                    } else {
+                        // Set the requested level before unmuting for the same reason.
+                        if (Math.abs(media.volume - target) > 0.001) { media.volume = target; }
+                        if (media.muted) { media.muted = false; }
+                    }
+                } catch (e) {}
+                applyPlayerTarget(target);
+            }
+
+            function applyNode(node) {
+                if (!node) { return; }
+                if (typeof HTMLMediaElement !== 'undefined' && node instanceof HTMLMediaElement) {
+                    applyTarget(node);
+                }
+                if (typeof node.querySelectorAll === 'function') {
+                    node.querySelectorAll('video, audio').forEach(applyTarget);
+                }
+            }
+
+            window.__kasetApplyTargetVolume = applyTarget;
+            window.__kasetApplyTargetVolumeToAllMedia = function() {
+                if (typeof document.querySelectorAll === 'function') {
+                    document.querySelectorAll('video, audio').forEach(applyTarget);
+                }
+                applyPlayerTarget(resolvedTarget());
+            };
+
+            const mediaPrototype = typeof HTMLMediaElement !== 'undefined'
+                ? HTMLMediaElement.prototype
+                : null;
+            function guardMediaAccessor(name, marker, valueForTarget) {
+                if (!mediaPrototype
+                    || Object.prototype.hasOwnProperty.call(mediaPrototype, marker)) {
+                    return;
+                }
+
+                const descriptor = Object.getOwnPropertyDescriptor(mediaPrototype, name);
+                if (!descriptor || !descriptor.configurable
+                    || typeof descriptor.get !== 'function'
+                    || typeof descriptor.set !== 'function') {
+                    return;
+                }
+
+                try {
+                    Object.defineProperty(mediaPrototype, name, {
+                        configurable: descriptor.configurable,
+                        enumerable: descriptor.enumerable,
+                        get: descriptor.get,
+                        set: function() {
+                            const target = resolvedTarget();
+                            descriptor.set.call(this, valueForTarget(target));
+                        }
+                    });
+                    Object.defineProperty(mediaPrototype, marker, {
+                        configurable: true,
+                        value: descriptor
+                    });
+                } catch (e) {}
+            }
+            guardMediaAccessor(
+                'volume',
+                '__kasetOriginalVolumeDescriptor',
+                function(target) { return target; }
+            );
+            guardMediaAccessor(
+                'muted',
+                '__kasetOriginalMutedDescriptor',
+                function(target) { return target <= 0; }
+            );
+
+            if (mediaPrototype && typeof mediaPrototype.play === 'function'
+                && !mediaPrototype.__kasetOriginalPlay) {
+                const originalPlay = mediaPrototype.play;
+                try {
+                    Object.defineProperty(mediaPrototype, '__kasetOriginalPlay', {
+                        configurable: true,
+                        value: originalPlay
+                    });
+                    mediaPrototype.play = function() {
+                        applyTarget(this);
+                        return originalPlay.apply(this, arguments);
+                    };
+                } catch (e) {}
+            }
+
+            if (typeof document.addEventListener === 'function') {
+                ['play', 'playing', 'loadedmetadata', 'canplay', 'volumechange'].forEach(function(name) {
+                    document.addEventListener(name, function(event) {
+                        applyTarget(event.target);
+                    }, true);
+                });
+            }
+
+            if (typeof MutationObserver === 'function' && document.documentElement) {
+                const audioObserver = new MutationObserver(function(records) {
+                    records.forEach(function(record) {
+                        if (!record.addedNodes) { return; }
+                        record.addedNodes.forEach(applyNode);
+                    });
+                    applyPlayerTarget(resolvedTarget());
+                });
+                audioObserver.observe(document.documentElement, { childList: true, subtree: true });
+                window.__kasetAudioGuardObserver = audioObserver;
+            }
+
+            window.__kasetApplyTargetVolumeToAllMedia();
+        })();
+        """
+    }
+
+    // swiftlint:enable function_body_length
 
     nonisolated static func watchURL(videoId: String, documentGeneration: UInt64) -> URL? {
         var components = URLComponents(string: "https://www.youtube.com/watch")

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
@@ -185,6 +185,12 @@ extension YouTubeWatchWebView {
                     }
 
                     const hasReadyMedia = !!(video.currentSrc && video.readyState >= 1);
+                    const hasMediaError = !!video.error;
+                    const data = videoData();
+                    const isLive = !!(
+                        (data && data.isLive === true)
+                        || (hasReadyMedia && !isFinite(video.duration))
+                    );
                     const pendingSeekApplied = window.__kasetPendingSeekApplied === true;
                     const pendingSeekFailed = window.__kasetPendingSeekFailed === true;
                     const pendingSeekTarget = window.__kasetPendingSeekResultTarget;
@@ -199,12 +205,13 @@ extension YouTubeWatchWebView {
                         progress: progress,
                         duration: duration,
                         hasReadyMedia: hasReadyMedia,
+                        hasMediaError: hasMediaError,
                         videoId: videoId,
                         boundVideoId: video.__kasetBoundVideoId || '',
                         title: currentTitle(),
                         isAd: isAdShowing(),
                         isAdSkippable: isAdSkippable(),
-                        isLive: live.live,
+                        isLive: isLive,
                         isAtLiveEdge: live.atEdge,
                         pendingSeekApplied: pendingSeekApplied,
                         pendingSeekFailed: pendingSeekFailed,
@@ -301,7 +308,10 @@ extension YouTubeWatchWebView {
             }
 
             function enforceVolume(video) {
-                if (window.__kasetIsSettingVolume) { return; }
+                if (typeof window.__kasetApplyTargetVolume === 'function') {
+                    window.__kasetApplyTargetVolume(video);
+                    return;
+                }
                 const target = window.__kasetTargetVolume;
                 // YouTube persists its own mute state across sessions; Kaset
                 // owns audio, so unmute whenever our target volume is audible.
@@ -312,10 +322,15 @@ extension YouTubeWatchWebView {
                         try { player.unMute(); } catch (e) {}
                     }
                 }
+                if (typeof target === 'number' && target <= 0 && !video.muted) {
+                    video.muted = true;
+                    const player = moviePlayer();
+                    if (player && typeof player.mute === 'function') {
+                        try { player.mute(); } catch (e) {}
+                    }
+                }
                 if (typeof target === 'number' && Math.abs(video.volume - target) > 0.01) {
-                    window.__kasetIsSettingVolume = true;
                     video.volume = target;
-                    setTimeout(function() { window.__kasetIsSettingVolume = false; }, 50);
                 }
             }
 
@@ -492,7 +507,7 @@ extension YouTubeWatchWebView {
                 ['play', 'playing'].forEach(function(evt) {
                     video.addEventListener(evt, handlePlaybackStarted);
                 });
-                ['pause', 'seeked', 'loadedmetadata', 'durationchange', 'canplay', 'waiting'].forEach(function(evt) {
+                ['pause', 'seeked', 'loadedmetadata', 'durationchange', 'canplay', 'waiting', 'error'].forEach(function(evt) {
                     video.addEventListener(evt, handlePlaybackStopped);
                 });
                 video.addEventListener('timeupdate', handleTimelineUpdate);
@@ -541,6 +556,29 @@ extension YouTubeWatchWebView {
             } else {
                 attachWithBoundedRetry();
             }
+        })();
+        """
+    }
+
+    /// Stops the chrome-hiding extraction and drops its style elements.
+    ///
+    /// Consent, CAPTCHA and sign-in interstitials are deliberately allowed to
+    /// commit in this WebView so the user can clear them, but the
+    /// document-start blackout hides every element — and a `visibility:
+    /// hidden` element cannot be hit-tested, so the form is both invisible and
+    /// unclickable. Revealing the page is the only way out of that dead end.
+    static var revealInterstitialScript: String {
+        """
+        (function() {
+            try {
+                if (typeof window.__kasetStopYTExtraction === 'function') {
+                    window.__kasetStopYTExtraction();
+                }
+            } catch (e) {}
+            ['kaset-yt-blackout', 'kaset-yt-video-style'].forEach(function(id) {
+                const style = document.getElementById(id);
+                if (style && style.parentNode) { style.parentNode.removeChild(style); }
+            });
         })();
         """
     }
@@ -1393,20 +1431,29 @@ extension YouTubeWatchWebView {
             """
             (function() {
                 window.__kasetTargetVolume = \(clamped);
-                window.__kasetIsSettingVolume = true;
+                if (typeof window.__kasetApplyTargetVolumeToAllMedia === 'function') {
+                    window.__kasetApplyTargetVolumeToAllMedia();
+                    return;
+                }
                 const video = document.querySelector('#movie_player video') || document.querySelector('video');
                 if (video) {
-                    video.volume = \(clamped);
-                    if (\(clamped) > 0 && video.muted) { video.muted = false; }
+                    if (\(clamped) <= 0) {
+                        video.muted = true;
+                        video.volume = 0;
+                    } else {
+                        video.volume = \(clamped);
+                        video.muted = false;
+                    }
                 }
                 const player = document.getElementById('movie_player');
                 if (player && typeof player.setVolume === 'function') {
                     player.setVolume(\(Int((clamped * 100).rounded())));
                 }
-                if (player && \(clamped) > 0 && typeof player.unMute === 'function') {
+                if (player && \(clamped) <= 0 && typeof player.mute === 'function') {
+                    try { player.mute(); } catch (e) {}
+                } else if (player && typeof player.unMute === 'function') {
                     try { player.unMute(); } catch (e) {}
                 }
-                setTimeout(function() { window.__kasetIsSettingVolume = false; }, 100);
             })();
             """,
             completionHandler: nil

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -2,21 +2,6 @@ import os
 import SwiftUI
 import WebKit
 
-// MARK: - ScrollPassthroughWebView
-
-/// WKWebView that forwards scroll-wheel events to the enclosing SwiftUI
-/// ScrollView. The extracted watch page is `overflow: hidden`, so the page
-/// never scrolls; without this, a hovered WebView swallows wheel events and
-/// dead-zones the surrounding scroll wherever the video sits. Forwarding to the
-/// next responder lets the watch page keep scrolling with the cursor over the
-/// video. In the floating window there is no scrollable ancestor, so it's a
-/// harmless no-op.
-final class ScrollPassthroughWebView: WKWebView {
-    override func scrollWheel(with event: NSEvent) {
-        self.nextResponder?.scrollWheel(with: event)
-    }
-}
-
 // MARK: - YouTubeWatchWebView
 
 /// Manages the single WebView used for regular YouTube video playback.
@@ -103,7 +88,7 @@ final class YouTubeWatchWebView {
             documentGeneration: Self.userScriptDocumentGeneration(from: self.documentGeneration)
         )
 
-        let newWebView = ScrollPassthroughWebView(frame: .zero, configuration: configuration)
+        let newWebView = ScrollForwardingWebView(frame: .zero, configuration: configuration)
         newWebView.navigationDelegate = self.coordinator
         newWebView.customUserAgent = WebKitManager.userAgent
         self.webKitManager = webKitManager
@@ -124,13 +109,20 @@ final class YouTubeWatchWebView {
     }
 
     /// Ensures the WebView fills the given container (reparenting if needed).
-    func ensureInHierarchy(container: NSView) {
+    func ensureInHierarchy(
+        container: NSView,
+        expectedVideoId: String? = nil,
+        selectedVideoId: String? = nil
+    ) {
         guard let webView else { return }
+        guard YouTubeWatchSurfaceAttachment.claim(
+            surface: webView,
+            in: container,
+            expectedVideoId: expectedVideoId,
+            currentVideoId: selectedVideoId
+        ) else { return }
         self.currentContainer = container
         self.webKitManager?.extensionHostWebViewDidBecomeActive(webView)
-        guard webView.superview !== container else { return }
-        webView.removeFromSuperview()
-        container.addSubview(webView)
         webView.translatesAutoresizingMaskIntoConstraints = true
         webView.frame = container.bounds
         webView.autoresizingMask = [.width, .height]
@@ -362,83 +354,6 @@ extension YouTubeWatchWebView {
         )
     }
 
-    func decideNavigationPolicy(
-        webView: WKWebView,
-        navigationAction: WKNavigationAction,
-        decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
-    ) {
-        guard navigationAction.targetFrame?.isMainFrame == true else {
-            decisionHandler(.allow)
-            return
-        }
-
-        if WebPlaybackDocumentGeneration.isInternalBlankNavigation(navigationAction.request.url) {
-            decisionHandler(
-                self.documentGeneration.ownsBlankNavigation(navigationAction.request.url)
-                    ? .allow
-                    : .cancel
-            )
-            return
-        }
-
-        if WebPlaybackDocumentGeneration.isFragmentOnlyNavigation(
-            from: webView.url,
-            to: navigationAction.request.url
-        ) {
-            self.webKitManager?.extensionHostWebViewWillNavigate(
-                webView,
-                to: navigationAction.request.url
-            )
-            decisionHandler(.allow)
-            return
-        }
-
-        if self.documentGeneration.pendingGeneration != nil {
-            decisionHandler(.cancel)
-            return
-        }
-
-        if let inFlightGeneration = self.documentGeneration.inFlightGeneration {
-            guard WebPlaybackDocumentGeneration.requestBelongsToNavigationChain(
-                navigationAction.request,
-                currentURL: webView.url,
-                generation: inFlightGeneration,
-                playbackHost: "www.youtube.com",
-                committedIntermediaryGeneration: self.documentGeneration.committedIntermediaryGeneration
-            ) else {
-                decisionHandler(.cancel)
-                return
-            }
-            if WebPlaybackDocumentGeneration.generation(from: navigationAction.request.url)
-                != inFlightGeneration
-            {
-                decisionHandler(.cancel)
-                self.continuationGenerationsAwaitingStart.insert(inFlightGeneration)
-                if let boundRequest = WebPlaybackDocumentGeneration.requestByBindingGeneration(
-                    navigationAction.request,
-                    generation: inFlightGeneration
-                ) {
-                    Task { @MainActor in
-                        self.startBoundNavigationContinuation(
-                            on: webView,
-                            request: boundRequest,
-                            generation: inFlightGeneration
-                        )
-                    }
-                }
-                return
-            }
-            self.webKitManager?.extensionHostWebViewWillNavigate(
-                webView,
-                to: navigationAction.request.url
-            )
-            decisionHandler(.allow)
-            return
-        }
-
-        decisionHandler(.cancel)
-    }
-
     private func refreshDocumentUserScripts(on webView: WKWebView) {
         let targetVolume = self.coordinator?.playerService.volume ?? 1.0
         let scriptGeneration = self.documentGeneration.userScriptGeneration
@@ -488,7 +403,7 @@ extension YouTubeWatchWebView {
         )
     }
 
-    private func startBoundNavigationContinuation(
+    func startBoundNavigationContinuation(
         on webView: WKWebView,
         request: URLRequest,
         generation: UInt64

--- a/Tests/KasetTests/AppLocalizationTests.swift
+++ b/Tests/KasetTests/AppLocalizationTests.swift
@@ -308,7 +308,7 @@ struct AppLocalizationTests {
         let title = String(format: localizedText, locale: Locale(identifier: "it"), "34.6M")
 
         #expect(artist == "Artista")
-        #expect(title.hasPrefix("Abbonati"))
+        #expect(title.hasPrefix("Iscriviti"))
         #expect(title.contains("34.6M"))
     }
 

--- a/Tests/KasetTests/FavoritesManagerLegacyMigrationClaimTests.swift
+++ b/Tests/KasetTests/FavoritesManagerLegacyMigrationClaimTests.swift
@@ -708,13 +708,17 @@ struct FavoritesManagerTestsLegacyMigrationClaims {
         manager.setActiveAccountScopeID(scopeID, legacyAccountID: accountID)
         #expect(!manager.canMutate)
 
-        try await Task.sleep(for: .milliseconds(60))
         try FileManager.default.setAttributes([.immutable: false], ofItemAtPath: directory.path)
         manager.recoverLegacyAccountFavorites(accountID: accountID, toScopeID: scopeID)
         #expect(manager.canMutate)
         manager.add(addedItem)
-        try await Task.sleep(for: .milliseconds(160))
 
+        let didRecover = await self.waitUntil(timeout: .seconds(2)) {
+            manager.isPinned(contentId: legacyItem.contentId)
+                && manager.isPinned(contentId: addedItem.contentId)
+        }
+
+        #expect(didRecover)
         #expect(manager.isPinned(contentId: existingItem.contentId))
         #expect(manager.isPinned(contentId: legacyItem.contentId))
         #expect(manager.isPinned(contentId: addedItem.contentId))
@@ -729,6 +733,21 @@ struct FavoritesManagerTestsLegacyMigrationClaims {
             .appendingPathComponent("FavoritesManagerTestsLegacyMigrationClaims-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         return directory
+    }
+
+    private func waitUntil(
+        timeout: Duration,
+        condition: @escaping @MainActor () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while clock.now < deadline {
+            if condition() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return condition()
     }
 
     private func legacyClaimURLs(in directory: URL) throws -> [URL] {

--- a/Tests/KasetTests/LocalizationCatalogParityTests.swift
+++ b/Tests/KasetTests/LocalizationCatalogParityTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Testing
+
+/// Packaged builds compile `Localizable.xcstrings` directly, while SwiftPM and
+/// Xcode runtime builds ship the checked-in `.lproj` mirrors. An edit that only
+/// reaches one side is therefore visible in one build path but stale or missing
+/// in the other, so the two have to be checked against each other.
+@Suite("Localization catalog parity")
+struct LocalizationCatalogParityTests {
+    @Test("Every .lproj value matches the string catalog")
+    func lprojMatchesCatalog() throws {
+        let resources = Self.resourcesDirectory
+        let catalogURL = resources.appendingPathComponent("Localizable.xcstrings")
+        let catalog = try Self.loadCatalog(at: catalogURL)
+        let catalogKeys = try Self.catalogKeys(at: catalogURL)
+        let sourceLanguage = try Self.sourceLanguage(at: catalogURL)
+
+        let localizationDirectories = try FileManager.default
+            .contentsOfDirectory(at: resources, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "lproj" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        #expect(!localizationDirectories.isEmpty)
+
+        var problems: [String] = []
+
+        // This fork intentionally ships only a subset of the catalog's languages
+        // as `.lproj` (see the resources list in Package.swift), so a catalog
+        // language without a matching `.lproj` is expected rather than drift —
+        // only the shipped locales are checked against the catalog below.
+
+        for directory in localizationDirectories {
+            let language = directory.deletingPathExtension().lastPathComponent
+            let stringsURL = directory.appendingPathComponent("Localizable.strings")
+            guard FileManager.default.fileExists(atPath: stringsURL.path) else {
+                problems.append("\(language): \(directory.lastPathComponent) has no Localizable.strings")
+                continue
+            }
+
+            let shippedStrings = try Self.loadStrings(at: stringsURL)
+            let catalogEntries = catalog[language] ?? [:]
+            // A shipped language the catalog no longer translates would ship
+            // stale strings forever, and comparing an empty dictionary would
+            // silently pass.
+            if catalogEntries.isEmpty, language != sourceLanguage {
+                problems.append("\(language): ships an .lproj but has no localizations in the catalog")
+                continue
+            }
+            // The catalog carries an empty-string placeholder key that the
+            // `.lproj` mirrors don't; skip it rather than flag every locale.
+            for (key, expected) in catalogEntries.sorted(by: { $0.key < $1.key }) where !key.isEmpty {
+                guard let actual = shippedStrings[key] else {
+                    // The source language needs no entry: the key is the value.
+                    if language != sourceLanguage {
+                        problems.append("\(language): \"\(key)\" is in the catalog but missing from .lproj")
+                    }
+                    continue
+                }
+                if actual != expected {
+                    problems.append(
+                        "\(language): \"\(key)\"\n  .lproj:  \"\(actual)\"\n  catalog: \"\(expected)\""
+                    )
+                }
+            }
+
+            // The other direction: a translated key dropped from this locale
+            // but left in its .strings file would silently ship a stale value.
+            // The source locale may intentionally override a subset of catalog
+            // keys because untranslated source keys are their own values.
+            let expectedShippedKeys = language == sourceLanguage
+                ? catalogKeys
+                : Set(catalogEntries.keys)
+            for key in shippedStrings.keys.sorted() where !expectedShippedKeys.contains(key) {
+                if language == sourceLanguage {
+                    problems.append("\(language): \"\(key)\" is in .lproj but no longer in the catalog")
+                } else {
+                    problems.append("\(language): \"\(key)\" is in .lproj but missing from that catalog locale")
+                }
+            }
+        }
+
+        #expect(
+            problems.isEmpty,
+            """
+            \(problems.count) localization(s) drifted from Localizable.xcstrings. \
+            Regenerate the affected .strings entries from the catalog:
+            \(problems.joined(separator: "\n"))
+            """
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// `Sources/Kaset/Resources`, resolved from this file rather than a bundle:
+    /// the catalog is deliberately excluded from the target's resources.
+    static var resourcesDirectory: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // KasetTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // repo root
+            .appendingPathComponent("Sources/Kaset/Resources")
+    }
+
+    /// The catalog's source language, whose `.strings` needs no entry per key
+    /// because the key itself is the value.
+    static func sourceLanguage(at url: URL) throws -> String {
+        let raw = try JSONSerialization.jsonObject(with: Data(contentsOf: url))
+        return (raw as? [String: Any])?["sourceLanguage"] as? String ?? "en"
+    }
+
+    /// Every key the catalog defines, regardless of which languages translate
+    /// it. Used to spot `.strings` entries the catalog has dropped.
+    static func catalogKeys(at url: URL) throws -> Set<String> {
+        let raw = try JSONSerialization.jsonObject(with: Data(contentsOf: url))
+        guard let strings = (raw as? [String: Any])?["strings"] as? [String: Any] else {
+            return []
+        }
+        return Set(strings.keys)
+    }
+
+    /// `[language: [key: value]]` from the string catalog.
+    static func loadCatalog(at url: URL) throws -> [String: [String: String]] {
+        let raw = try JSONSerialization.jsonObject(with: Data(contentsOf: url))
+        guard let root = raw as? [String: Any],
+              let strings = root["strings"] as? [String: Any]
+        else {
+            return [:]
+        }
+
+        var catalog: [String: [String: String]] = [:]
+        for (key, entry) in strings {
+            guard let entry = entry as? [String: Any],
+                  let localizations = entry["localizations"] as? [String: Any]
+            else { continue }
+            for (language, localization) in localizations {
+                guard let localization = localization as? [String: Any],
+                      let unit = localization["stringUnit"] as? [String: Any],
+                      let value = unit["value"] as? String
+                else { continue }
+                catalog[language, default: [:]][key] = value
+            }
+        }
+        return catalog
+    }
+
+    /// Parses a text-format `.strings` file (old-style property list).
+    static func loadStrings(at url: URL) throws -> [String: String] {
+        let parsed = try PropertyListSerialization.propertyList(
+            from: Data(contentsOf: url),
+            options: [],
+            format: nil
+        )
+        return parsed as? [String: String] ?? [:]
+    }
+}

--- a/Tests/KasetTests/WebPlaybackDocumentGenerationTests.swift
+++ b/Tests/KasetTests/WebPlaybackDocumentGenerationTests.swift
@@ -611,6 +611,87 @@ struct WebPlaybackDocumentGenerationTests {
         #expect(WebPlaybackDocumentGeneration.generation(from: rebound.url) == 42)
     }
 
+    @Test("Trusted intermediary form POSTs stay intact in their committed generation")
+    func trustedIntermediaryPostPassesThrough() throws {
+        let consent = try #require(URL(string: "https://consent.youtube.com/m"))
+        var request = try URLRequest(url: #require(URL(string: "https://consent.youtube.com/s")))
+        request.httpMethod = "POST"
+
+        #expect(WebPlaybackDocumentGeneration.shouldAllowTrustedIntermediaryFormSubmission(
+            request,
+            currentURL: consent,
+            generation: 42,
+            playbackHost: "www.youtube.com",
+            committedIntermediaryGeneration: 42
+        ))
+
+        var getRequest = request
+        getRequest.httpMethod = "GET"
+        #expect(!WebPlaybackDocumentGeneration.shouldAllowTrustedIntermediaryFormSubmission(
+            getRequest,
+            currentURL: consent,
+            generation: 42,
+            playbackHost: "www.youtube.com",
+            committedIntermediaryGeneration: 42
+        ))
+
+        #expect(!WebPlaybackDocumentGeneration.shouldAllowTrustedIntermediaryFormSubmission(
+            request,
+            currentURL: consent,
+            generation: 42,
+            playbackHost: "www.youtube.com",
+            committedIntermediaryGeneration: 41
+        ))
+
+        let untrusted = try #require(URL(string: "https://example.test/form"))
+        #expect(!WebPlaybackDocumentGeneration.shouldAllowTrustedIntermediaryFormSubmission(
+            request,
+            currentURL: untrusted,
+            generation: 42,
+            playbackHost: "www.youtube.com",
+            committedIntermediaryGeneration: 42
+        ))
+    }
+
+    @Test("A trusted intermediary POST redirect rebinds its tokenless playback GET")
+    func trustedIntermediaryPostRedirectRebindsTokenlessGet() throws {
+        let consentURL = try #require(URL(string: "https://consent.youtube.com/m"))
+        var postRequest = try URLRequest(url: #require(URL(string: "https://consent.youtube.com/s")))
+        postRequest.httpMethod = "POST"
+        #expect(WebPlaybackDocumentGeneration.shouldAllowTrustedIntermediaryFormSubmission(
+            postRequest,
+            currentURL: consentURL,
+            generation: 42,
+            playbackHost: "www.youtube.com",
+            committedIntermediaryGeneration: 42
+        ))
+
+        let redirectedGet = try URLRequest(url: #require(URL(
+            string: "https://www.youtube.com/watch?v=video"
+        )))
+        #expect(WebPlaybackDocumentGeneration.requestBelongsToNavigationChain(
+            redirectedGet,
+            currentURL: consentURL,
+            generation: 42,
+            playbackHost: "www.youtube.com",
+            committedIntermediaryGeneration: 42
+        ))
+        #expect(!WebPlaybackDocumentGeneration.shouldAllowTrustedIntermediaryFormSubmission(
+            redirectedGet,
+            currentURL: consentURL,
+            generation: 42,
+            playbackHost: "www.youtube.com",
+            committedIntermediaryGeneration: 42
+        ))
+
+        let rebound = try #require(WebPlaybackDocumentGeneration.requestByBindingGeneration(
+            redirectedGet,
+            generation: 42
+        ))
+        #expect(WebPlaybackDocumentGeneration.generation(from: rebound.url) == 42)
+        #expect(WebPlaybackDocumentGeneration.generation(from: rebound.mainDocumentURL) == 42)
+    }
+
     @Test("Bridge generation decoding rejects malformed values")
     func bridgeGenerationDecoding() {
         let generation = WebPlaybackDocumentGeneration()

--- a/Tests/KasetTests/YouTubeDocumentStartAudioGuardTests.swift
+++ b/Tests/KasetTests/YouTubeDocumentStartAudioGuardTests.swift
@@ -1,0 +1,251 @@
+import JavaScriptCore
+import Testing
+import WebKit
+@testable import KasetPlus
+
+@Suite("YouTube document-start audio guard", .tags(.service))
+@MainActor
+struct YouTubeDocumentStartAudioGuardTests {
+    @Test("A muted document cannot become audible before the observer attaches")
+    func mutedDocumentGatesFirstPlay() throws {
+        let context = try #require(JSContext())
+        context.evaluateScript(Self.mediaHarness)
+        context.evaluateScript(YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 0,
+            documentGeneration: 1
+        ))
+        context.evaluateScript("video = new HTMLMediaElement(); video.play();")
+
+        #expect(context.evaluateScript("audibleStartCount").toInt32() == 0)
+        #expect(context.evaluateScript("video.volume").toDouble() == 0)
+        #expect(context.evaluateScript("video.muted").toBool())
+    }
+
+    @Test("Native autoplay capture is muted before the document-end observer exists")
+    func mutedDocumentGatesNativeAutoplay() throws {
+        let context = try #require(JSContext())
+        context.evaluateScript(Self.mediaHarness)
+        context.evaluateScript(YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 0,
+            documentGeneration: 1
+        ))
+        context.evaluateScript("video = new HTMLMediaElement(); documentListeners.play({ target: video });")
+
+        #expect(context.evaluateScript("video.volume").toDouble() == 0)
+        #expect(context.evaluateScript("video.muted").toBool())
+    }
+
+    @Test("Replacement media is muted as soon as it is inserted")
+    func mutedDocumentGatesReplacementMedia() throws {
+        let context = try #require(JSContext())
+        context.evaluateScript(Self.mediaHarness)
+        context.evaluateScript(YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 0,
+            documentGeneration: 1
+        ))
+        context.evaluateScript("video = new HTMLMediaElement(); mutationCallback([{ addedNodes: [video] }]);")
+
+        #expect(context.evaluateScript("video.volume").toDouble() == 0)
+        #expect(context.evaluateScript("video.muted").toBool())
+    }
+
+    @Test("YouTube cannot restore an audible persisted volume while Kaset is muted")
+    func mutedDocumentReassertsVolumeAfterReset() throws {
+        let context = try #require(JSContext())
+        context.evaluateScript(Self.mediaHarness)
+        context.evaluateScript(YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 0,
+            documentGeneration: 1
+        ))
+        context.evaluateScript(
+            "video = new HTMLMediaElement(); video.play(); video.volume = 0.73; video.muted = false; documentListeners.volumechange({ target: video });"
+        )
+
+        #expect(context.evaluateScript("video.volume").toDouble() == 0)
+        #expect(context.evaluateScript("video.muted").toBool())
+    }
+
+    @Test("Persisted volume restoration cannot become audible before volumechange dispatch")
+    func mutedDocumentBlocksSynchronousVolumeRestoration() throws {
+        for restorationScript in [
+            "video.volume = 0.73; video.muted = false;",
+            "video.muted = false; video.volume = 0.73;",
+        ] {
+            let context = try #require(JSContext())
+            context.evaluateScript(Self.mediaHarness)
+            context.evaluateScript(YouTubeWatchWebView.pageBootstrapScript(
+                targetVolume: 0,
+                documentGeneration: 1
+            ))
+            context.evaluateScript(
+                "video = new HTMLMediaElement(); video.play(); audibleStateTransitionCount = 0; \(restorationScript)"
+            )
+
+            #expect(context.evaluateScript("queuedVolumeChangeTargets.length").toInt32() > 0)
+            #expect(context.evaluateScript("audibleStateTransitionCount").toInt32() == 0)
+            #expect(context.evaluateScript("video.volume").toDouble() == 0)
+            #expect(context.evaluateScript("video.muted").toBool())
+        }
+    }
+
+    @Test("An audible target is applied before unmuting first play")
+    func audibleDocumentAppliesTargetBeforePlay() throws {
+        let context = try #require(JSContext())
+        context.evaluateScript(Self.mediaHarness)
+        context.evaluateScript(YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 0.4,
+            documentGeneration: 1
+        ))
+        context.evaluateScript("video = new HTMLMediaElement(); video.muted = true; video.play();")
+
+        #expect(abs(context.evaluateScript("volumeAtPlay").toDouble() - 0.4) < 0.001)
+        #expect(!context.evaluateScript("mutedAtPlay").toBool())
+    }
+
+    @Test("An audible target rejects persisted volume and mute writes synchronously")
+    func audibleDocumentBlocksPersistedStateRestoration() throws {
+        for restorationScript in [
+            "video.volume = 0.91; video.muted = true;",
+            "video.muted = true; video.volume = 0.91;",
+        ] {
+            let context = try #require(JSContext())
+            context.evaluateScript(Self.mediaHarness)
+            context.evaluateScript(YouTubeWatchWebView.pageBootstrapScript(
+                targetVolume: 0.4,
+                documentGeneration: 1
+            ))
+            context.evaluateScript(
+                "video = new HTMLMediaElement(); video.play(); \(restorationScript)"
+            )
+
+            #expect(abs(context.evaluateScript("video.volume").toDouble() - 0.4) < 0.001)
+            #expect(!context.evaluateScript("video.muted").toBool())
+        }
+    }
+
+    @Test("The document-start guard synchronizes the YouTube player API")
+    func audioGuardSynchronizesPlayerAPI() throws {
+        let context = try #require(JSContext())
+        context.evaluateScript(Self.mediaHarness)
+        context.evaluateScript(
+            """
+            moviePlayer = {
+                volume: 73,
+                muted: false,
+                getVolume: function() { return this.volume; },
+                setVolume: function(value) { this.volume = value; },
+                isMuted: function() { return this.muted; },
+                mute: function() { this.muted = true; },
+                unMute: function() { this.muted = false; }
+            };
+            """
+        )
+        context.evaluateScript(YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 0,
+            documentGeneration: 1
+        ))
+
+        #expect(context.evaluateScript("moviePlayer.volume").toInt32() == 0)
+        #expect(context.evaluateScript("moviePlayer.muted").toBool())
+    }
+
+    @Test("A native volume change reuses the document-start guard")
+    func updatedTargetReusesAudioGuard() throws {
+        let context = try #require(JSContext())
+        context.evaluateScript(Self.mediaHarness)
+        context.evaluateScript(YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 0,
+            documentGeneration: 1
+        ))
+        context.evaluateScript(
+            "video = new HTMLMediaElement(); video.play(); window.__kasetTargetVolume = 0.4; window.__kasetApplyTargetVolumeToAllMedia = function() { window.__kasetApplyTargetVolume(video); }; window.__kasetApplyTargetVolumeToAllMedia();"
+        )
+
+        #expect(abs(context.evaluateScript("video.volume").toDouble() - 0.4) < 0.001)
+        #expect(!context.evaluateScript("video.muted").toBool())
+    }
+
+    @Test("The audio guard is installed at document start")
+    func audioGuardUsesDocumentStartInjection() throws {
+        let contentController = WKUserContentController()
+        YouTubeWatchWebView.shared.installUserScripts(
+            on: contentController,
+            targetVolume: 0,
+            documentGeneration: 1
+        )
+
+        let bootstrap = try #require(contentController.userScripts.first)
+        #expect(bootstrap.injectionTime == .atDocumentStart)
+        #expect(bootstrap.isForMainFrameOnly)
+        #expect(bootstrap.source.contains("__kasetApplyTargetVolume"))
+        #expect(bootstrap.source.contains("HTMLMediaElement"))
+    }
+
+    private static let mediaHarness = """
+    var audibleStartCount = 0;
+    var volumeAtPlay = null;
+    var mutedAtPlay = null;
+    var audibleStateTransitionCount = 0;
+    var queuedVolumeChangeTargets = [];
+    var documentListeners = {};
+    var moviePlayer = null;
+
+    function HTMLMediaElement() {
+        this._volume = 0.73;
+        this._muted = false;
+        this.paused = true;
+        this.readyState = 0;
+    }
+    function recordMediaState(media) {
+        if (!media.paused && !media.muted && media.volume > 0) {
+            audibleStateTransitionCount += 1;
+        }
+    }
+    Object.defineProperty(HTMLMediaElement.prototype, 'volume', {
+        configurable: true,
+        get: function() { return this._volume; },
+        set: function(value) {
+            this._volume = value;
+            recordMediaState(this);
+            queuedVolumeChangeTargets.push(this);
+        }
+    });
+    Object.defineProperty(HTMLMediaElement.prototype, 'muted', {
+        configurable: true,
+        get: function() { return this._muted; },
+        set: function(value) {
+            this._muted = value;
+            recordMediaState(this);
+            queuedVolumeChangeTargets.push(this);
+        }
+    });
+    HTMLMediaElement.prototype.play = function() {
+        volumeAtPlay = this.volume;
+        mutedAtPlay = this.muted;
+        if (!this.muted && this.volume > 0) { audibleStartCount += 1; }
+        this.paused = false;
+        return true;
+    };
+
+    var document = {
+        documentElement: {},
+        addEventListener: function(name, listener) { documentListeners[name] = listener; },
+        querySelectorAll: function() { return []; },
+        getElementById: function(id) { return id === 'movie_player' ? moviePlayer : null; }
+    };
+    var mutationCallback = null;
+    function MutationObserver(callback) {
+        mutationCallback = callback;
+        this.observe = function() {};
+        this.disconnect = function() {};
+    }
+
+    var window = globalThis;
+    window.location = { search: '', hash: '' };
+    window.webkit = {
+        messageHandlers: {
+            youtubePlayer: { postMessage: function() {} }
+        }
+    };
+    """
+}

--- a/Tests/KasetTests/YouTubeInterstitialScriptContractTests.swift
+++ b/Tests/KasetTests/YouTubeInterstitialScriptContractTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import KasetPlus
+
+@Suite("YouTube interstitial script contracts", .tags(.service))
+@MainActor
+struct YouTubeInterstitialScriptContractTests {
+    @Test("Reveal matches the blackout and extraction contracts")
+    func interstitialRevealContract() {
+        let reveal = YouTubeWatchWebView.revealInterstitialScript
+        let blackout = YouTubeWatchWebView.blackoutScript
+        let extraction = YouTubeWatchWebView.extractionScript
+
+        #expect(blackout.contains("style.id = 'kaset-yt-blackout'"))
+        #expect(extraction.contains("const styleId = 'kaset-yt-video-style'"))
+        #expect(extraction.contains("window.__kasetStopYTExtraction = stopExtraction"))
+        #expect(reveal.contains("typeof window.__kasetStopYTExtraction === 'function'"))
+        #expect(reveal.contains("'kaset-yt-blackout', 'kaset-yt-video-style'"))
+    }
+}

--- a/Tests/KasetTests/YouTubeItemParserTests.swift
+++ b/Tests/KasetTests/YouTubeItemParserTests.swift
@@ -473,6 +473,57 @@ struct YouTubeItemParserTests {
         #expect(short.title == "A Short Title")
         #expect(short.viewCountText == "2.1M views")
         #expect(short.isShort)
+        #expect(short.thumbnailURL?.absoluteString == "https://example.com/short.jpg")
+    }
+
+    @Test("Parses a shortsLockupViewModel with a nested thumbnailViewModel")
+    func parsesShortsLockupNestedThumbnail() throws {
+        let lockup: [String: Any] = [
+            "entityId": "shorts-shelf-item-X4dGtpUD3gA",
+            "onTap": [
+                "innertubeCommand": [
+                    "reelWatchEndpoint": ["videoId": "X4dGtpUD3gA"],
+                ],
+            ],
+            "overlayMetadata": [
+                "primaryText": ["content": "A Short Title"],
+            ],
+            "thumbnailViewModel": [
+                "thumbnailViewModel": [
+                    "image": [
+                        "sources": [
+                            ["url": "https://example.com/oardefault.jpg", "width": 405, "height": 720],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+
+        let short = try #require(YouTubeItemParser.short(fromShortsLockup: lockup))
+        #expect(short.thumbnailURL?.absoluteString == "https://example.com/oardefault.jpg")
+    }
+
+    @Test("Parses a playlist lockup's collectionThumbnailViewModel poster")
+    func parsesCollectionThumbnailLockup() throws {
+        let lockup: [String: Any] = [
+            "contentImage": [
+                "collectionThumbnailViewModel": [
+                    "primaryThumbnail": [
+                        "thumbnailViewModel": [
+                            "image": [
+                                "sources": [
+                                    ["url": "https://example.com/small.jpg", "width": 360, "height": 202],
+                                    ["url": "https://example.com/hq720.jpg", "width": 720, "height": 404],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+
+        let url = try #require(YouTubeItemParser.thumbnailURL(fromLockup: lockup))
+        #expect(url.absoluteString == "https://example.com/hq720.jpg")
     }
 
     @Test("Feed collection separates Shorts from regular videos")
@@ -515,4 +566,63 @@ struct YouTubeItemParserTests {
         #expect(YouTubeItemParser.text(from: nil) == nil)
         #expect(YouTubeItemParser.text(from: ["runs": [[String: Any]]()]) == nil)
     }
+
+    // MARK: - Recorded payloads
+
+    /// Guards the lockup thumbnail key paths against the shapes InnerTube
+    /// actually sends, which handwritten payloads have drifted from before.
+    @Test("Recorded Shorts and playlist lockups yield thumbnails")
+    func recordedLockupsYieldThumbnails() throws {
+        let watchNext = try Self.loadFixture("youtube_watch_next")
+        let shortsLockups = Self.collect(key: "shortsLockupViewModel", in: watchNext)
+        #expect(!shortsLockups.isEmpty)
+        for lockup in shortsLockups {
+            let short = try #require(YouTubeItemParser.short(fromShortsLockup: lockup))
+            #expect(short.thumbnailURL != nil, "Short \(short.videoId) parsed without a thumbnail")
+        }
+
+        let playlists = try Self.loadFixture("youtube_search_playlists")
+        let collectionLockups = Self.collect(key: "lockupViewModel", in: playlists)
+            .filter {
+                ($0["contentImage"] as? [String: Any])?["collectionThumbnailViewModel"] != nil
+            }
+        #expect(!collectionLockups.isEmpty)
+        for lockup in collectionLockups {
+            #expect(YouTubeItemParser.thumbnailURL(fromLockup: lockup) != nil)
+        }
+    }
+
+    // MARK: - Fixture Helpers
+
+    static func loadFixture(_ name: String) throws -> [String: Any] {
+        guard let url = Bundle.module.url(forResource: name, withExtension: "json") else {
+            throw FixtureError.notFound(name)
+        }
+        guard let fixture = try JSONSerialization
+            .jsonObject(with: Data(contentsOf: url)) as? [String: Any]
+        else {
+            throw FixtureError.invalidJSON(name)
+        }
+        return fixture
+    }
+
+    /// Every dictionary stored under `key`, at any depth.
+    static func collect(key: String, in value: Any) -> [[String: Any]] {
+        var found: [[String: Any]] = []
+        if let dict = value as? [String: Any] {
+            if let match = dict[key] as? [String: Any] {
+                found.append(match)
+            }
+            for nested in dict.values {
+                found.append(contentsOf: self.collect(key: key, in: nested))
+            }
+        } else if let array = value as? [Any] {
+            for element in array {
+                found.append(contentsOf: self.collect(key: key, in: element))
+            }
+        }
+        return found
+    }
+
+    enum FixtureError: Error { case notFound(String), invalidJSON(String) }
 }

--- a/Tests/KasetTests/YouTubePlayerLoadingTimeoutTests.swift
+++ b/Tests/KasetTests/YouTubePlayerLoadingTimeoutTests.swift
@@ -1,0 +1,279 @@
+import Testing
+@testable import KasetPlus
+
+@Suite("YouTube loading timeout", .serialized, .tags(.service))
+@MainActor
+struct YouTubePlayerLoadingTimeoutTests {
+    @Test("Settled empty media becomes reloadable after the bounded fallback")
+    func emptyMediaBecomesReloadableAfterTimeout() async throws {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(
+            playbackController: controller,
+            playbackLoadingTimeout: .milliseconds(10)
+        )
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        service.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            hasMediaError: false,
+            videoId: "abc"
+        ))
+
+        #expect(service.isPlaybackLoading)
+        try await self.waitUntil { !service.isPlaybackLoading }
+        #expect(!service.isPlaybackLoading)
+        #expect(controller.cancelPendingLoadCount == 1)
+        #expect(service.pendingPausedIdentityReloadVideoId == "abc")
+
+        service.playPause()
+
+        #expect(controller.reloadedVideoIds == ["abc"])
+        #expect(controller.playCount == 0)
+        #expect(controller.pauseCount == 0)
+    }
+
+    @Test("A pre-ready SPA drift restarts the bounded loading fallback")
+    func preReadyDriftRestartsLoadingTimeout() async throws {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(
+            playbackController: controller,
+            playbackLoadingTimeout: .milliseconds(10)
+        )
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        service.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            hasMediaError: false,
+            videoId: "b",
+            boundVideoId: "a"
+        ))
+
+        #expect(service.currentVideo?.videoId == "b")
+        #expect(service.isPlaybackLoading)
+        try await self.waitUntil { !service.isPlaybackLoading }
+        #expect(!service.isPlaybackLoading)
+    }
+
+    @Test("A timed-out active navigation is cancelled before it is deferred")
+    func timedOutActiveNavigationIsCancelled() async throws {
+        let controller = MockYouTubeWatchPlaybackController()
+        controller.cancelPendingLoadResult = true
+        let service = YouTubePlayerService(
+            playbackController: controller,
+            playbackLoadingTimeout: .milliseconds(10)
+        )
+        controller.onCancelPendingLoad = { [weak service] in
+            service?.handleWebNavigationCancellation()
+        }
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        service.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            hasMediaError: false,
+            videoId: "abc"
+        ))
+
+        try await self.waitUntil { !service.isPlaybackLoading }
+
+        #expect(controller.cancelPendingLoadCount == 1)
+        #expect(service.pendingPausedIdentityReloadVideoId == "abc")
+        service.playPause()
+        #expect(controller.reloadedVideoIds == ["abc"])
+    }
+
+    @Test("A late playing update cannot consume a timed-out deferred reload")
+    func latePlayingUpdateCannotConsumeTimedOutReload() async throws {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(
+            playbackController: controller,
+            playbackLoadingTimeout: .milliseconds(10)
+        )
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        service.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            hasMediaError: false,
+            videoId: "abc"
+        ))
+        try await self.waitUntil { !service.isPlaybackLoading }
+
+        service.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 0,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
+
+        #expect(service.pendingPausedIdentityReloadVideoId == "abc")
+        #expect(controller.reloadedVideoIds.isEmpty)
+        #expect(!service.isPlaying)
+        #expect(controller.pauseCount == 1)
+
+        service.playPause()
+        #expect(controller.reloadedVideoIds == ["abc"])
+    }
+
+    @Test("An unready SPA drift starts loading after outgoing media was ready")
+    func unreadyDriftStartsLoadingAfterReadyOutgoingMedia() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(
+            playbackController: controller,
+            playbackLoadingTimeout: .seconds(1)
+        )
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        service.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 15,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a"
+        ))
+        #expect(!service.isPlaybackLoading)
+
+        service.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            videoId: "b",
+            boundVideoId: "a"
+        ))
+
+        #expect(service.currentVideo?.videoId == "b")
+        #expect(service.isPlaybackLoading)
+    }
+
+    @Test("Ready outgoing media does not clear the incoming video's loading cycle")
+    func readyOutgoingMediaDoesNotClearIncomingLoading() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(
+            playbackController: controller,
+            playbackLoadingTimeout: .milliseconds(10)
+        )
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        service.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 15,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "b",
+            boundVideoId: "a"
+        ))
+
+        #expect(service.currentVideo?.videoId == "b")
+        #expect(service.isPlaybackLoading)
+    }
+
+    @Test("Ready incoming media completes loading after page drift")
+    func readyIncomingMediaCompletesLoadingAfterDrift() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(playbackController: controller)
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        service.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 0,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "b",
+            boundVideoId: "b"
+        ))
+
+        #expect(service.currentVideo?.videoId == "b")
+        #expect(!service.isPlaybackLoading)
+    }
+
+    @Test("A stale ready advertisement does not clear a newer video's loading cycle")
+    func staleReadyAdvertisementDoesNotClearIncomingLoading() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(
+            playbackController: controller,
+            playbackLoadingTimeout: .milliseconds(10)
+        )
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "b"))
+        service.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 0,
+            duration: 15,
+            hasReadyMedia: true,
+            videoId: "creative",
+            boundVideoId: "a",
+            isAd: true
+        ))
+
+        #expect(service.currentVideo?.videoId == "b")
+        #expect(service.isPlaybackLoading)
+    }
+
+    @Test("A timed-out identity reload remains retryable after pause and resume")
+    func timedOutIdentityReloadRemainsRetryable() async throws {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(
+            playbackController: controller,
+            playbackLoadingTimeout: .milliseconds(10)
+        )
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        service.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 12,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
+
+        service.reloadCurrentVideoForIdentitySwitch()
+        try await self.waitUntil { !service.isPlaybackLoading }
+        #expect(!service.isPlaybackLoading)
+
+        service.pause()
+        service.resume()
+
+        #expect(controller.reloadedVideoIds == ["abc", "abc"])
+        #expect(controller.playCount == 0)
+    }
+
+    @Test("A same-video replacement load receives its own timeout window")
+    func sameVideoReplacementReceivesIndependentTimeout() async throws {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(
+            playbackController: controller,
+            playbackLoadingTimeout: .seconds(1)
+        )
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+
+        try await Task.sleep(for: .milliseconds(700))
+        service.reloadCurrentVideoForIdentitySwitch()
+        try await Task.sleep(for: .milliseconds(400))
+
+        #expect(service.isPlaybackLoading)
+
+        try await self.waitUntil(
+            timeout: .seconds(2),
+            condition: { !service.isPlaybackLoading }
+        )
+        #expect(!service.isPlaybackLoading)
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(10),
+        condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !condition(), clock.now < deadline {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+    }
+}

--- a/Tests/KasetTests/YouTubePlayerMediaErrorTests.swift
+++ b/Tests/KasetTests/YouTubePlayerMediaErrorTests.swift
@@ -1,0 +1,113 @@
+import Testing
+@testable import KasetPlus
+
+@Suite("YouTube media-error recovery", .serialized, .tags(.service))
+@MainActor
+struct YouTubePlayerMediaErrorTests {
+    private let controller: MockYouTubeWatchPlaybackController
+    private let sut: YouTubePlayerService
+
+    init() {
+        self.controller = MockYouTubeWatchPlaybackController()
+        self.sut = YouTubePlayerService(playbackController: self.controller)
+    }
+
+    @Test("A media error clears loading even when media never becomes ready")
+    func mediaErrorClearsNeverReadyLoading() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            hasMediaError: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
+
+        #expect(!self.sut.isPlaybackLoading)
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == "abc")
+
+        self.sut.resume()
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+    }
+
+    @Test("An active-document media error recovers before video identity is available")
+    func unboundMediaErrorDefersCurrentVideo() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            hasMediaError: true
+        ))
+
+        #expect(!self.sut.isPlaybackLoading)
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == "abc")
+
+        self.sut.resume()
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+    }
+
+    @Test("A stale outgoing media error does not defer the newly reported video")
+    func staleOutgoingMediaErrorDoesNotDeferNewVideo() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            hasMediaError: true,
+            videoId: "b",
+            boundVideoId: "a"
+        ))
+
+        #expect(self.sut.currentVideo?.videoId == "b")
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == nil)
+        #expect(self.sut.isPlaybackLoading)
+    }
+
+    @Test("An incoming media error follows and defers the incoming video")
+    func incomingMediaErrorDefersIncomingVideo() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            hasMediaError: true,
+            videoId: "b",
+            boundVideoId: "b"
+        ))
+
+        #expect(self.sut.currentVideo?.videoId == "b")
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == "b")
+        #expect(!self.sut.isPlaybackLoading)
+
+        self.sut.resume()
+        #expect(self.controller.reloadedVideoIds == ["b"])
+    }
+
+    @Test("An advertisement media error does not defer the content video")
+    func advertisementMediaErrorDoesNotDeferContentVideo() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            hasMediaError: true,
+            videoId: "abc",
+            boundVideoId: "abc",
+            isAd: true
+        ))
+
+        #expect(self.sut.currentVideo?.videoId == "abc")
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == nil)
+        #expect(self.sut.isPlaybackLoading)
+    }
+}

--- a/Tests/KasetTests/YouTubePlayerRecoveryTests.swift
+++ b/Tests/KasetTests/YouTubePlayerRecoveryTests.swift
@@ -208,9 +208,11 @@ struct YouTubePlayerRecoveryTests {
             duration: 15,
             hasReadyMedia: true,
             videoId: "abc",
+            boundVideoId: "abc",
             isAd: true
         ))
 
+        #expect(!self.sut.isPlaybackLoading)
         self.sut.playPause()
 
         #expect(self.controller.playCount == 1)

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -24,6 +24,7 @@ final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackControlling 
     private(set) var prepareCount = 0
     private(set) var cancelPendingLoadCount = 0
     var cancelPendingLoadResult = false
+    var onCancelPendingLoad: (() -> Void)?
     var onLoadVideo: ((String) -> Void)?
     var onSeek: ((Double) -> Void)?
 
@@ -43,6 +44,7 @@ final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackControlling 
 
     func cancelPendingLoad() -> Bool {
         self.cancelPendingLoadCount += 1
+        self.onCancelPendingLoad?()
         return self.cancelPendingLoadResult
     }
 
@@ -251,8 +253,16 @@ struct YouTubePlayerServiceTests {
     @Test("Network restored leaves a normally-playing video alone")
     func networkRestoredIgnoresHealthyPlayback() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
-        // A playback update clears the loading state and marks it playing.
-        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 5, duration: 60, videoId: "abc"))
+        // A ready-media update for the current video finishes loading and marks
+        // it playing (loading now clears on ready media, not a duration proxy).
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 5,
+            duration: 60,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
         #expect(!self.sut.isPlaybackLoading)
 
         self.sut.handleNetworkRestored()
@@ -1691,7 +1701,7 @@ extension YouTubePlayerServiceTests {
         self.controller.captionTracks = [
             YouTubeCaptionTrack(languageCode: "en", displayName: "English"),
         ]
-        self.controller.quality = ["hd1080", "hd720", "auto"]
+        self.controller.quality = ["hd1080", "hd720"]
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
 
         await self.sut.refreshPlaybackOptions()
@@ -1705,7 +1715,150 @@ extension YouTubePlayerServiceTests {
 
         self.sut.selectQuality("hd720")
         #expect(self.sut.currentQuality == "hd720")
+        #expect(self.sut.userPinnedQuality == "hd720")
         #expect(self.controller.selectedQuality == "hd720")
+
+        self.sut.selectQuality("auto")
+        #expect(self.sut.currentQuality == "auto")
+        #expect(self.sut.userPinnedQuality == nil)
+        #expect(self.controller.selectedQuality == "auto")
+
+        self.sut.selectQuality("hd1080")
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "xyz"))
+        #expect(self.sut.userPinnedQuality == nil)
+    }
+
+    @Test("Playback options do not duplicate Auto and remain unavailable when empty")
+    func playbackOptionAutoBranches() async {
+        self.controller.captionTracks = [
+            YouTubeCaptionTrack(languageCode: "en", displayName: "English"),
+        ]
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+
+        self.controller.quality = ["hd1080", "auto"]
+        await self.sut.refreshPlaybackOptions()
+        #expect(self.sut.qualityLevels == ["hd1080", "auto"])
+
+        self.controller.quality = []
+        await self.sut.refreshPlaybackOptions()
+        #expect(self.sut.qualityLevels.isEmpty)
+    }
+
+    @Test("Runtime live state prevents terminal seek handling after SPA drift")
+    func runtimeLiveStatePreventsTerminalSeekAfterDrift() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 10,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a"
+        ))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 99,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "live-b",
+            boundVideoId: "live-b",
+            isLive: true
+        ))
+
+        #expect(self.sut.currentVideo?.videoId == "live-b")
+        #expect(self.sut.currentVideo?.isLive == true)
+
+        self.sut.seek(to: 100)
+
+        #expect(self.controller.markCurrentPlaybackOccurrenceEndedCount == 0)
+        #expect(self.controller.pauseCount == 0)
+        #expect(self.controller.pendingRecoverySeeks.last == 100)
+    }
+
+    @Test("A later ready snapshot repairs SPA-drifted live metadata")
+    func readySnapshotRepairsDriftedLiveMetadata() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            videoId: "live-b",
+            boundVideoId: "a",
+            isLive: false
+        ))
+        #expect(self.sut.currentVideo?.videoId == "live-b")
+        #expect(self.sut.currentVideo?.isLive == false)
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 5,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "live-b",
+            boundVideoId: "live-b",
+            isLive: true
+        ))
+
+        #expect(self.sut.currentVideo?.isLive == true)
+    }
+
+    @Test("Leading live metadata does not relabel outgoing bound media")
+    func leadingLiveMetadataDoesNotRelabelOutgoingMedia() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 10,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a",
+            isLive: false
+        ))
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 11,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "live-b",
+            boundVideoId: "a",
+            isLive: true
+        ))
+
+        #expect(self.sut.currentVideo?.videoId == "live-b")
+        #expect(self.sut.currentVideo?.isLive == false)
+        #expect(!self.sut.currentMediaIsLive)
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 1,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "live-b",
+            boundVideoId: "live-b",
+            isLive: true
+        ))
+
+        #expect(self.sut.currentVideo?.isLive == true)
+        #expect(self.sut.currentMediaIsLive)
+    }
+
+    @Test("A negative runtime sample does not downgrade known live metadata")
+    func negativeRuntimeSamplePreservesKnownLiveMetadata() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "live", isLive: true))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 5,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "live",
+            boundVideoId: "live",
+            isLive: false
+        ))
+
+        #expect(self.sut.currentVideo?.isLive == true)
+        #expect(self.sut.currentMediaIsLive)
     }
 
     @Test("Source switch pauses the docked video in place — no pop-out")

--- a/Tests/KasetTests/YouTubeWatchLiveStateScriptTests.swift
+++ b/Tests/KasetTests/YouTubeWatchLiveStateScriptTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import KasetPlus
+
+extension YouTubeWatchScriptTests {
+    @Test("Archived live-origin media is not reported as currently live")
+    func archivedLiveOriginIsNotCurrentlyLive() throws {
+        let context = try self.makeObserverContext(paused: false)
+        try self.evaluate(
+            """
+            moviePlayer.getVideoData = function() {
+                return {
+                    video_id: 'abc123',
+                    title: 'Archived Stream',
+                    isLive: false,
+                    isLiveContent: true
+                };
+            };
+            video.duration = 120;
+            """,
+            in: context
+        )
+
+        try self.evaluate(YouTubeWatchWebView.observerScript, in: context)
+
+        #expect(context.evaluateScript("postedMessages[0].isLive").toBool() == false)
+    }
+}

--- a/Tests/KasetTests/YouTubeWatchScriptTests.swift
+++ b/Tests/KasetTests/YouTubeWatchScriptTests.swift
@@ -29,6 +29,8 @@ struct YouTubeWatchScriptTests {
         #expect(payloads.contains { $0.contains("type: 'VIDEO_ENDED'") })
         let statePayload = payloads.first { $0.contains("type: 'STATE_UPDATE'") }
         #expect(statePayload?.contains("hasReadyMedia: hasReadyMedia") == true)
+        #expect(statePayload?.contains("hasMediaError: hasMediaError") == true)
+        #expect(statePayload?.contains("isLive: isLive") == true)
         #expect(statePayload?.contains("pendingSeekApplied: pendingSeekApplied") == true)
         #expect(statePayload?.contains("pendingSeekFailed: pendingSeekFailed") == true)
         #expect(statePayload?.contains("pendingSeekVideoId: pendingSeekVideoId") == true)

--- a/Tests/KasetTests/YouTubeWatchSurfaceOwnershipTests.swift
+++ b/Tests/KasetTests/YouTubeWatchSurfaceOwnershipTests.swift
@@ -1,0 +1,64 @@
+import AppKit
+import Testing
+@testable import KasetPlus
+
+// MARK: - YouTubeWatchSurfaceOwnershipTests
+
+@MainActor
+struct YouTubeWatchSurfaceOwnershipTests {
+    @Test("A late outgoing Shorts host cannot reclaim the selected surface")
+    func lateOutgoingShortsHostCannotReclaimSelectedSurface() {
+        let surface = NSView()
+        let firstContainer = NSView()
+        let secondContainer = NSView()
+
+        #expect(YouTubeWatchSurfaceAttachment.claim(
+            surface: surface,
+            in: firstContainer,
+            expectedVideoId: "short-a",
+            currentVideoId: "short-a"
+        ))
+        #expect(YouTubeWatchSurfaceAttachment.claim(
+            surface: surface,
+            in: secondContainer,
+            expectedVideoId: "short-b",
+            currentVideoId: "short-b"
+        ))
+        #expect(!YouTubeWatchSurfaceAttachment.claim(
+            surface: surface,
+            in: firstContainer,
+            expectedVideoId: "short-a",
+            currentVideoId: "short-b"
+        ))
+        #expect(!YouTubeWatchSurfaceAttachment.claim(
+            surface: surface,
+            in: firstContainer,
+            expectedVideoId: "short-a",
+            currentVideoId: nil
+        ))
+
+        #expect(surface.superview === secondContainer)
+        #expect(!firstContainer.subviews.contains { $0 === surface })
+    }
+
+    @Test("Unscoped watch and floating hosts retain existing handoff behavior")
+    func unscopedHostsCanClaimSurface() {
+        let surface = NSView()
+        let watchContainer = NSView()
+        let floatingContainer = NSView()
+
+        #expect(YouTubeWatchSurfaceAttachment.claim(
+            surface: surface,
+            in: watchContainer,
+            expectedVideoId: nil,
+            currentVideoId: nil
+        ))
+        #expect(YouTubeWatchSurfaceAttachment.claim(
+            surface: surface,
+            in: floatingContainer,
+            expectedVideoId: nil,
+            currentVideoId: "current-video"
+        ))
+        #expect(surface.superview === floatingContainer)
+    }
+}

--- a/docs/adr/0026-generation-scoped-web-playback-bridge.md
+++ b/docs/adr/0026-generation-scoped-web-playback-bridge.md
@@ -49,14 +49,26 @@ Every full-page playback navigation receives a monotonically increasing
   selected item as a deferred retry rather than re-authorizing an outgoing page
   that may represent different content.
 - Main-frame document navigations not initiated by Kaset are cancelled; the
-  hidden playback pages are not user-facing browser tabs. Fragment-only
-  same-document navigation is left alone. While a navigation is reserved, other
-  document-changing page actions are cancelled; while it is provisional, only
-  requests carrying that provisional generation are allowed only across the
-  expected HTTPS playback origin and an explicit allowlist of Google/YouTube
-  consent or authentication origins. Trusted intermediates remain provisional;
-  only the expected playback origin may commit and publish bridge messages.
-  Captive-portal and unrelated error origins are cancelled into the retry path.
+  playback document itself remains a hidden media surface rather than a general
+  browser tab. Fragment-only same-document navigation is left alone. While a
+  navigation is reserved, other document-changing page actions are cancelled;
+  while it is provisional, only requests associated with that generation may
+  cross the expected HTTPS playback origin or an explicit allowlist of
+  Google/YouTube consent and authentication origins.
+- An allowlisted HTTPS consent or authentication intermediary may commit as the
+  current WebKit document and is temporarily revealed so the user can complete
+  the interaction. Its generation remains in-flight, so it cannot publish
+  playback bridge state; only the expected playback origin activates the
+  generation. Tokenless GET continuations are rebound with the generation
+  token. A tokenless POST is passed through unchanged only when the committed
+  intermediary generation matches, both the current and destination URLs are
+  trusted intermediaries, and any `mainDocumentURL` generation is absent or
+  matching. This narrow exception preserves form bodies that WebKit omits from
+  the navigation-policy request. A server-redirected tokenless GET re-enters
+  navigation-action policy and is cancelled and restarted with the generation
+  token before response validation. Untrusted origins, captive portals,
+  unrelated error pages, and unsupported challenges remain in the
+  cancellation/retry path.
 - Starting a newer explicit load cancels the previous provisional load before
   replacing the WebView-wide user-script list. Server redirects refresh the
   bootstrap fallback; redirect requests remain associated through the original


### PR DESCRIPTION
## **User description**
Hand-merged cherry-pick of upstream sozercan/kaset #408 (`dfdb4ba`, "improve YouTube playback reliability") onto the fork's 175-commit divergence, reconciled with the fork's #19 (⌘R refresh + network auto-retry).

**Taken (reliability core):** loading-timeout + media-error recovery, runtime liveness (`currentMediaIsLive`), `ScrollForwardingWebView`, generalized interstitial handling (`isTrustedIntermediaryURL`), item-parser thumbnail helpers, new reliability test suites.

**Kept the fork's version:** PlayerBar / ShortsView / VideoWindowController (overflow menu, shorts rail, PiP always-on-top), plus the #374 perf optimization and ad-skip/live-edge fields. Subscribe strings → "Iscriviti" (free sense).

**Follow-up fixes** (same branch): restored the fork's duration>0 loading-finish so Shorts load, and `ScrollForwardingWebView` forwards to nextResponder to fix watch-page scroll lag.

No playback/reliability test regressed. Pre-existing test-target failures on main (AppLocalizationTests, SettingsManager/ListenBrainz, storyboard flake) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Improve YouTube playback recovery, audio control, and watch-page interaction

### What Changed
- Stuck or failed video loads now recover through automatic timeout and media-error retry, while live streams no longer pause or appear finished when seeking to the live edge
- Playback volume and mute settings are enforced before media starts, preventing a brief audible burst or unwanted restored volume
- Consent and sign-in pages can be revealed and completed without breaking the playback retry flow; unsupported traffic challenges remain blocked
- Scrolling works over the video surface, and outdated Shorts pages can no longer reclaim the active player
- Shorts and playlist results now retain thumbnails across additional YouTube response formats, and quality controls consistently offer an Auto option
- Added coverage for playback recovery, audio protection, interstitial navigation, live detection, thumbnails, localization parity, and player ownership

### Impact
`✅ Fewer videos stuck loading`
`✅ No unintended audio during playback startup`
`✅ Smoother scrolling and Shorts transitions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
