### PR TITLE
YouTube-style autoplay with an up-next countdown card

### DIFF
--- a/Sources/Kaset/Resources/Localizable.xcstrings
+++ b/Sources/Kaset/Resources/Localizable.xcstrings
@@ -11669,6 +11669,17 @@
         }
       }
     },
+    "Autoplay" : {
+      "comment" : "Toggle: automatically play the next suggested video (it: 'Riproduzione automatica').",
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riproduzione automatica"
+          }
+        }
+      }
+    },
     "Available" : {
       "comment" : "Reusable label shown in the Foundation Models screen, Intelligence settings.",
       "localizations" : {
@@ -73135,6 +73146,17 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Play songs from a playlist or album to build your queue."
+          }
+        }
+      }
+    },
+    "Play now" : {
+      "comment" : "Tooltip on the autoplay countdown play button (it: 'Riproduci ora').",
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riproduci ora"
           }
         }
       }

--- a/Sources/Kaset/Resources/it.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/it.lproj/Localizable.strings
@@ -62,6 +62,7 @@
 "Auto" = "Automatico";
 "Auto-skips sponsored segments in videos." = "Auto-skips sponsored segments in videos.";
 "Automatically check for updates" = "Controlla automaticamente gli aggiornamenti";
+"Autoplay" = "Riproduzione automatica";
 "Available" = "Disponibile";
 "Back 30 seconds" = "Indietro di 30 secondi";
 "Background Playback" = "Riproduzione in background";
@@ -395,6 +396,7 @@
 "Play Next" = "Riproduci dopo";
 "Play a song to view its lyrics here." = "Riproduci un brano per vederne qui il testo.";
 "Play songs from a playlist or album to build your queue." = "Riproduci brani da una playlist o da un album per creare la tua coda.";
+"Play now" = "Riproduci ora";
 "Play video" = "Riproduci video";
 "Playback" = "Riproduzione";
 "Playback Audio Quality" = "Qualità audio di riproduzione";

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -416,6 +416,16 @@ final class YouTubePlayerService {
     /// Up-next candidates for skip-forward (related videos from the watch page).
     private(set) var upNext: [YouTubeVideo] = []
 
+    /// The video queued to autoplay next, shown behind a countdown card after the
+    /// current video finishes (YouTube-style). Nil when no autoplay is pending.
+    private(set) var autoplayPendingVideo: YouTubeVideo?
+    /// Whole seconds left on the autoplay countdown (counts `autoplayCountdownSeconds`→0);
+    /// meaningful only while `autoplayPendingVideo` is set.
+    private(set) var autoplayCountdownRemaining = 0
+    @ObservationIgnored private var autoplayCountdownTask: Task<Void, Never>?
+    /// How long the "up next" countdown card lingers before advancing.
+    static let autoplayCountdownSeconds = 5
+
     /// Navigation chapters for the current video, loaded from the watch page's
     /// companion `next` response.
     private(set) var chapters: [YouTubeChapter] = []
@@ -516,6 +526,7 @@ final class YouTubePlayerService {
     /// Starts playback of a video, docked inline.
     func play(video: YouTubeVideo, usesCookieFreeDataStore: Bool = false, startAt: Double? = nil) {
         self.beginYouTubePlaybackIntent()
+        self.clearAutoplayCountdown()
         self.autoplayRecoveryRequestGeneration &+= 1
         self.shouldRecoverAutoplayTransitionOnResume = false
         let normalizedStartAt = Self.normalizedExplicitStartAt(startAt)
@@ -935,6 +946,7 @@ final class YouTubePlayerService {
     /// Stops playback entirely and releases the surface.
     func stop() {
         self.beginYouTubePlaybackIntent()
+        self.clearAutoplayCountdown()
         self.autoplayRecoveryRequestGeneration &+= 1
         self.shouldRecoverAutoplayTransitionOnResume = false
         self.logger.info("YouTubePlayer: stop")
@@ -1076,6 +1088,7 @@ final class YouTubePlayerService {
     }
 
     private func advance(to video: YouTubeVideo, recordingHistory: Bool = true) {
+        self.clearAutoplayCountdown()
         self.autoplayRecoveryRequestGeneration &+= 1
         self.shouldRecoverAutoplayTransitionOnResume = false
         self.logger.info("YouTubePlayer: advancing to another video")
@@ -1990,7 +2003,78 @@ extension YouTubePlayerService {
             self.watchActivityGeneration += 1
             self.onVideoEnded?(videoId)
         }
+        self.autoplayNextIfEnabled()
         return true
+    }
+
+    /// YouTube-style autoplay: when the setting is on, a finished video queues the
+    /// next suggested video (the first up-next candidate, or a freshly fetched
+    /// related video when none are known — e.g. a floating-window finish) behind a
+    /// countdown card, rather than switching immediately. Off by default, so
+    /// playback otherwise stops at the end. Mixes and playlists advance through
+    /// their own queue via page drift and are unaffected by this.
+    private func autoplayNextIfEnabled() {
+        guard SettingsManager.shared.youtubeAutoplayEnabled,
+              let current = self.currentVideo
+        else { return }
+
+        if let next = self.upNext.first {
+            self.startAutoplayCountdown(to: next)
+            return
+        }
+        let expectedVideoId = current.videoId
+        Task { @MainActor in
+            guard let client = self.youtubeClient,
+                  let next = try? await client.getWatchNext(videoId: expectedVideoId, playlistId: nil)
+                  .related.first(where: { !$0.isShort }),
+                  SettingsManager.shared.youtubeAutoplayEnabled,
+                  self.currentVideo?.videoId == expectedVideoId,
+                  self.autoplayPendingVideo == nil
+            else { return }
+            self.startAutoplayCountdown(to: next)
+        }
+    }
+
+    private func startAutoplayCountdown(to next: YouTubeVideo) {
+        self.autoplayCountdownTask?.cancel()
+        self.autoplayPendingVideo = next
+        self.autoplayCountdownRemaining = Self.autoplayCountdownSeconds
+        self.autoplayCountdownTask = Task { [weak self] in
+            while true {
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    return
+                }
+                guard let self, self.autoplayPendingVideo?.videoId == next.videoId else { return }
+                self.autoplayCountdownRemaining -= 1
+                if self.autoplayCountdownRemaining <= 0 {
+                    self.confirmAutoplayNow()
+                    return
+                }
+            }
+        }
+    }
+
+    /// Plays the queued autoplay video right away (the countdown card's play
+    /// button — "speed it up").
+    func confirmAutoplayNow() {
+        guard let next = self.autoplayPendingVideo else { return }
+        self.clearAutoplayCountdown()
+        self.advance(to: next)
+    }
+
+    /// Dismisses the autoplay countdown without advancing (the card's cancel
+    /// button, or any explicit playback the user starts instead).
+    func cancelAutoplay() {
+        self.clearAutoplayCountdown()
+    }
+
+    private func clearAutoplayCountdown() {
+        self.autoplayCountdownTask?.cancel()
+        self.autoplayCountdownTask = nil
+        self.autoplayPendingVideo = nil
+        self.autoplayCountdownRemaining = 0
     }
 
     nonisolated static func isEndEventStale(

--- a/Sources/Kaset/Services/SettingsManager.swift
+++ b/Sources/Kaset/Services/SettingsManager.swift
@@ -44,6 +44,7 @@ final class SettingsManager {
         static let dearrowEnabled = "settings.dearrow.enabled"
         static let hasCompletedInitialOnboarding = "settings.onboarding.completed"
         static let distractionFreeEnabled = "settings.distractionFree.enabled"
+        static let youtubeAutoplayEnabled = "settings.youtube.autoplay.enabled"
         static let accentColorHex = "settings.accentColorHex"
         #if DEBUG
             static let useLegacyMacOS15UI = "settings.debug.useLegacyMacOS15UI"
@@ -569,6 +570,15 @@ final class SettingsManager {
         }
     }
 
+    /// YouTube-style autoplay: when a video finishes, automatically play the next
+    /// suggested (up-next) video. Off by default; the fork otherwise stops at the
+    /// end (YouTube's own autonav is always disabled).
+    var youtubeAutoplayEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(self.youtubeAutoplayEnabled, forKey: Keys.youtubeAutoplayEnabled)
+        }
+    }
+
     /// Whether the one-time first-launch onboarding (the addons walkthrough)
     /// has been completed. The full onboarding — changelog → Continue → Addons →
     /// Done — is shown only once, on first launch. Later versions surface just the
@@ -665,6 +675,7 @@ final class SettingsManager {
         self.dearrowEnabled = UserDefaults.standard.object(forKey: Keys.dearrowEnabled) as? Bool ?? false
         self.hasCompletedInitialOnboarding = UserDefaults.standard.object(forKey: Keys.hasCompletedInitialOnboarding) as? Bool ?? false
         self.distractionFreeEnabled = UserDefaults.standard.object(forKey: Keys.distractionFreeEnabled) as? Bool ?? false
+        self.youtubeAutoplayEnabled = UserDefaults.standard.object(forKey: Keys.youtubeAutoplayEnabled) as? Bool ?? false
         #if DEBUG
             self.useLegacyMacOS15UI = UserDefaults.standard.object(forKey: Keys.useLegacyMacOS15UI) as? Bool ?? false
         #endif

--- a/Sources/Kaset/Views/YouTube/YouTubeAutoplayCountdownOverlay.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeAutoplayCountdownOverlay.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+// MARK: - YouTubeAutoplayCountdownOverlay
+
+/// YouTube-style "up next" countdown card, shown over the video surface after a
+/// video finishes when autoplay is on: it names the next video and counts down
+/// inside a ring the user can click to play now ("speed it up"), or cancel.
+///
+/// Reads the shared `YouTubePlayerService`, so both the inline watch view and the
+/// floating window can host it; it renders nothing when no autoplay is pending.
+struct YouTubeAutoplayCountdownOverlay: View {
+    @Environment(YouTubePlayerService.self) private var youtubePlayer
+
+    var body: some View {
+        if let next = self.youtubePlayer.autoplayPendingVideo {
+            self.card(next: next)
+                .transition(.opacity)
+        }
+    }
+
+    private func card(next: YouTubeVideo) -> some View {
+        let total = YouTubePlayerService.autoplayCountdownSeconds
+        let remaining = max(self.youtubePlayer.autoplayCountdownRemaining, 0)
+        let fraction = CGFloat(remaining) / CGFloat(max(total, 1))
+
+        return ZStack {
+            Rectangle().fill(.black.opacity(0.62))
+
+            VStack(spacing: 14) {
+                Text("Up Next", comment: "Label above the autoplay countdown card")
+                    .font(.system(size: 12, weight: .semibold))
+                    .textCase(.uppercase)
+                    .foregroundStyle(.white.opacity(0.7))
+
+                Text(next.title)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+
+                // The ring counts down; clicking it plays the next video now.
+                Button {
+                    self.youtubePlayer.confirmAutoplayNow()
+                } label: {
+                    ZStack {
+                        Circle().stroke(.white.opacity(0.25), lineWidth: 3)
+                        Circle()
+                            .trim(from: 0, to: fraction)
+                            .stroke(.white, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                            .rotationEffect(.degrees(-90))
+                        Text("\(remaining)")
+                            .font(.system(size: 22, weight: .semibold).monospacedDigit())
+                            .foregroundStyle(.white)
+                    }
+                    .frame(width: 62, height: 62)
+                    .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .help(Text("Play now", comment: "Tooltip on the autoplay countdown play button"))
+
+                Button {
+                    self.youtubePlayer.cancelAutoplay()
+                } label: {
+                    Text("Cancel", comment: "Button to cancel autoplay to the next video")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 16)
+                        .frame(height: 30)
+                        .compatGlass(interactive: true, tint: nil, in: Capsule())
+                        .contentShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(24)
+            .frame(maxWidth: 440)
+        }
+        .animation(.linear(duration: 1), value: remaining)
+    }
+}

--- a/Sources/Kaset/Views/YouTube/YouTubeVideoWindowController.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeVideoWindowController.swift
@@ -383,6 +383,10 @@ private struct YouTubeVideoWindowContent: View {
             ZStack(alignment: .bottom) {
                 YouTubeWatchSurfaceView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .overlay {
+                        YouTubeAutoplayCountdownOverlay()
+                    }
+                    .animation(.easeInOut(duration: 0.25), value: self.youtubePlayer.autoplayPendingVideo == nil)
 
                 if self.isHovering {
                     // The full player bar — same items as the main window.

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
@@ -260,6 +260,12 @@ struct YouTubeWatchView: View {
                 }
                 .animation(.easeInOut(duration: 0.25), value: self.youtubePlayer.isPlaybackLoading)
                 .animation(.easeInOut(duration: 0.25), value: self.viewModel.membersGate == nil)
+                // YouTube-style "up next" countdown card when a finished video is
+                // about to autoplay the next one.
+                .overlay {
+                    YouTubeAutoplayCountdownOverlay()
+                }
+                .animation(.easeInOut(duration: 0.25), value: self.youtubePlayer.autoplayPendingVideo == nil)
                 // "Ad" badge: a server-side (SSAI) ad can still slip past the
                 // blocker; label it so it's clear this isn't the content.
                 .overlay(alignment: .topLeading) {
@@ -1265,8 +1271,29 @@ struct YouTubeWatchView: View {
     }
 
     private var relatedHeader: some View {
-        Text("Related", comment: "Related videos section header")
-            .font(.title3.bold())
+        HStack(alignment: .firstTextBaseline) {
+            Text("Related", comment: "Related videos section header")
+                .font(.title3.bold())
+            Spacer(minLength: 12)
+            self.autoplayToggle
+        }
+    }
+
+    /// YouTube-style "Autoplay" switch: when on, a finished video advances to the
+    /// next suggested video. Off by default. Lives in the related header, like
+    /// YouTube's up-next autoplay toggle.
+    private var autoplayToggle: some View {
+        Toggle(isOn: Binding(
+            get: { self.settings.youtubeAutoplayEnabled },
+            set: { self.settings.youtubeAutoplayEnabled = $0 }
+        )) {
+            Text("Autoplay", comment: "Toggle: automatically play the next suggested video")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .toggleStyle(.switch)
+        .controlSize(.mini)
+        .fixedSize()
     }
 
     private var relatedSkeleton: some View {

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -794,6 +794,82 @@ struct YouTubePlayerServiceTests {
         #expect(didAcceptEnd)
     }
 
+    @Test("Autoplay off: a finished video queues nothing and does not advance")
+    func autoplayOffDoesNotQueueNext() {
+        let settings = SettingsManager.shared
+        let original = settings.youtubeAutoplayEnabled
+        defer { settings.youtubeAutoplayEnabled = original }
+        settings.youtubeAutoplayEnabled = false
+
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 9, duration: 10, videoId: "a"))
+        self.sut.setUpNext([MockYouTubeClient.makeVideo(videoId: "b")])
+
+        _ = self.sut.handleVideoEnded(videoId: "a")
+
+        #expect(self.sut.autoplayPendingVideo == nil)
+        #expect(self.sut.currentVideo?.videoId == "a")
+        #expect(!self.controller.loadedVideoIds.contains("b"))
+    }
+
+    @Test("Autoplay on: a finished video queues the next behind a countdown, not an instant switch")
+    func autoplayOnQueuesCountdown() {
+        let settings = SettingsManager.shared
+        let original = settings.youtubeAutoplayEnabled
+        defer { settings.youtubeAutoplayEnabled = original }
+        settings.youtubeAutoplayEnabled = true
+
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 9, duration: 10, videoId: "a"))
+        self.sut.setUpNext([MockYouTubeClient.makeVideo(videoId: "b")])
+
+        _ = self.sut.handleVideoEnded(videoId: "a")
+
+        // Queued, not switched: the card counts down before advancing.
+        #expect(self.sut.autoplayPendingVideo?.videoId == "b")
+        #expect(self.sut.autoplayCountdownRemaining == YouTubePlayerService.autoplayCountdownSeconds)
+        #expect(self.sut.currentVideo?.videoId == "a")
+        #expect(!self.controller.loadedVideoIds.contains("b"))
+    }
+
+    @Test("Confirming the countdown plays the next video immediately")
+    func autoplayConfirmAdvancesNow() {
+        let settings = SettingsManager.shared
+        let original = settings.youtubeAutoplayEnabled
+        defer { settings.youtubeAutoplayEnabled = original }
+        settings.youtubeAutoplayEnabled = true
+
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 9, duration: 10, videoId: "a"))
+        self.sut.setUpNext([MockYouTubeClient.makeVideo(videoId: "b")])
+        _ = self.sut.handleVideoEnded(videoId: "a")
+
+        self.sut.confirmAutoplayNow()
+
+        #expect(self.sut.currentVideo?.videoId == "b")
+        #expect(self.controller.loadedVideoIds.contains("b"))
+        #expect(self.sut.autoplayPendingVideo == nil)
+    }
+
+    @Test("Cancelling the countdown clears it without advancing")
+    func autoplayCancelClears() {
+        let settings = SettingsManager.shared
+        let original = settings.youtubeAutoplayEnabled
+        defer { settings.youtubeAutoplayEnabled = original }
+        settings.youtubeAutoplayEnabled = true
+
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 9, duration: 10, videoId: "a"))
+        self.sut.setUpNext([MockYouTubeClient.makeVideo(videoId: "b")])
+        _ = self.sut.handleVideoEnded(videoId: "a")
+
+        self.sut.cancelAutoplay()
+
+        #expect(self.sut.autoplayPendingVideo == nil)
+        #expect(self.sut.currentVideo?.videoId == "a")
+        #expect(!self.controller.loadedVideoIds.contains("b"))
+    }
+
     @Test("Duplicate ended callbacks run one-shot effects once and later autoplay can end")
     func duplicateEndedCallbacksAreIdempotentPerWatch() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))


### PR DESCRIPTION
## **User description**
Adds a YouTube-style **Autoplay** toggle (default **off**) to the related header. When on, a finished video queues the next suggested video behind a countdown card over the surface — **Up Next** + the next title, a **5s ring you can click to play now**, or **Cancel**. On timeout/click it advances and starts playing automatically. Mixes/playlists are unaffected (their own queue advances via page drift).

- `SettingsManager.youtubeAutoplayEnabled` (default off, persisted)
- Countdown state + confirm/cancel in `YouTubePlayerService`, cleared by play/stop/advance
- Reusable `YouTubeAutoplayCountdownOverlay` hosted by both the inline watch view and the floating window
- Tests for off/queued/confirm/cancel

Note: `AppLocalizationTests` stays red exactly as on main (fork-only keys pending Crowdin propagation); the catalog↔lproj parity test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add optional YouTube-style autoplay for suggested videos

### What Changed
- Adds an Autoplay switch to the Related section; it is off by default and remembers the user’s choice
- When enabled, a finished video shows the next suggested video with a five-second countdown instead of switching immediately
- Users can play the suggested video immediately, cancel autoplay, or let the countdown advance automatically
- The countdown card appears in both the main player and floating video window
- Mixes and playlists continue using their existing queue behavior

### Impact
`✅ User-controlled autoplay`
`✅ Clearer next-video choice`
`✅ Fewer unexpected video switches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
